### PR TITLE
fix: update checklist e2e tests for done-expanded default

### DIFF
--- a/tests/e2e/checklist.spec.ts
+++ b/tests/e2e/checklist.spec.ts
@@ -50,9 +50,8 @@ test.describe('Checklist', () => {
 		await expect(page.getByTestId('checklist-toggle-done')).toContainText('1 done');
 		await page.getByTestId('close-editor-btn').click();
 
-		// And reopening the note shows the item in the done section
+		// And reopening the note shows the item in the done section (expanded by default)
 		await noteCard(page, 'Tasks').click();
-		await page.getByTestId('checklist-toggle-done').click();
 		await expect(page.getByTestId('checklist-done-checkbox').first()).toBeChecked();
 	});
 
@@ -102,10 +101,7 @@ test.describe('Checklist', () => {
 		await expect(page.getByTestId('checklist-toggle-done')).toBeVisible();
 		await expect(page.getByTestId('checklist-toggle-done')).toContainText('1 done');
 
-		// When the user expands the done section
-		await page.getByTestId('checklist-toggle-done').click();
-
-		// Then the completed items are shown in the done section
+		// Then the completed items are shown in the done section (expanded by default)
 		await expect(page.getByTestId('checklist-done-section')).toBeVisible();
 		await expect(page.getByTestId('checklist-done-section')).toContainText('Done task');
 	});


### PR DESCRIPTION
## Summary
- Fix 2 failing checklist e2e tests caused by `doneExpanded` defaulting to `true` (changed in fed0fc1)
- Tests were clicking the done toggle to expand, but it was already expanded — so the click collapsed it instead

## Test plan
- [x] All 13 checklist e2e tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)