### PR TITLE
fix: add missing thumbnail_path migration and upload error feedback

### DIFF
--- a/src/lib/components/ImageUpload.svelte
+++ b/src/lib/components/ImageUpload.svelte
@@ -7,6 +7,7 @@
 	import { optimizeImage } from '$lib/utils/image-optimize.js';
 	import { browser } from '$app/environment';
 	import { addPendingAttachment, type PendingAttachment } from '$lib/sync/idb.js';
+	import { showToast } from '$lib/stores/toast.js';
 
 	interface Props {
 		noteId: string;
@@ -85,9 +86,13 @@
 				if (res.ok) {
 					const attachment = await res.json();
 					onUpload(attachment);
+				} else {
+					console.error('Upload failed:', res.status, await res.text());
+					showToast('Failed to upload image', 'error');
 				}
 			} catch (err) {
 				console.error('Upload failed:', err);
+				showToast('Failed to upload image', 'error');
 			}
 			uploading = false;
 		}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -85,7 +85,12 @@ sqlite.exec(`
 	CREATE INDEX IF NOT EXISTS sync_log_timestamp_idx ON sync_log(timestamp);
 `);
 
-// Idempotent migration: add featured column to attachments
+// Idempotent migrations: add columns that may be missing from older DBs
+try {
+	sqlite.exec(`ALTER TABLE attachments ADD COLUMN thumbnail_path TEXT;`);
+} catch {
+	// Column already exists
+}
 try {
 	sqlite.exec(`ALTER TABLE attachments ADD COLUMN featured INTEGER NOT NULL DEFAULT 0;`);
 } catch {


### PR DESCRIPTION
DBs created before the image upload feature had no thumbnail_path column in the attachments table. Since CREATE TABLE IF NOT EXISTS is a no-op for existing tables, the column was never added, causing silent insert failures.

Add idempotent ALTER TABLE migration for thumbnail_path and surface upload errors via toast notifications instead of swallowing them silently.

## Summary

What does this PR do and why?

## Test Plan

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated (if user-facing)
- [ ] `make check` passes
- [ ] `make test` passes

## Related Issues

Closes #

## Screenshots

If this changes the UI, include before/after screenshots.
