### PR TITLE
fix: resolve race condition in offline sync e2e test

### DIFF
--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -62,8 +62,9 @@ test.describe('Offline Support', () => {
 		await expect(page.getByText('Survive Reload')).toBeVisible();
 
 		// When the network is restored and sync completes
+		const syncResponse = page.waitForResponse('**/api/sync');
 		await page.context().setOffline(false);
-		await page.waitForResponse('**/api/sync');
+		await syncResponse;
 
 		// And the user reloads the page
 		await page.reload();


### PR DESCRIPTION
Set up waitForResponse before calling setOffline(false) so the sync
response listener is registered before the online event fires.

https://claude.ai/code/session_014yTnHzjkCJLBcYcPTSLVkE