### PR TITLE
fix: use pointer events for backdrop close instead of timeout 

### DIFF
--- a/src/lib/components/NoteEditor.svelte
+++ b/src/lib/components/NoteEditor.svelte
@@ -255,7 +255,6 @@
 	<div
 		class="mx-4 flex w-full max-w-xl md:max-w-2xl flex-col overflow-hidden rounded-sm border border-[var(--border)] shadow-[var(--card-shadow)] animate-[pop-in_150ms_ease-out]"
 		style={bgStyle}
-		onpointerdown={(e) => e.stopPropagation()}
 		onkeydown={(e) => { e.stopPropagation(); handleKeydown(e); }}
 		data-testid="note-editor"
 	>


### PR DESCRIPTION
## Summary

- Switch the note editor backdrop from mouse events to pointer events — pointer events are never synthetically re-dispatched from touch, so the tap that opens the editor can no longer ghost-click the overlay on mobile first load
- Use `e.target === e.currentTarget` checks on both `pointerdown` and `pointerup` to ensure only direct clicks on the backdrop trigger close
- Remove `stopPropagation` on the editor card since the target checks make it unnecessary — this also fixes a regression where the formatting toolbar dropdown wouldn't close when clicking outside it

## Root cause

On mobile, tapping a NoteCard triggers a `click` that opens the editor overlay. The browser then fires synthetic `mousedown`/`mouseup`/`click` events at the original tap coordinates (~300ms later on first page load). Since the overlay is full-screen, these synthetic events land on the backdrop, immediately closing the editor.

The previous fix used `requestAnimationFrame` (~16ms) to ignore early events, but on first load the main thread is busy with hydration, so the synthetic events arrive well after the rAF callback.

## Fix

Pointer events (`pointerdown`/`pointerup`) are the real interaction events — browsers don't re-dispatch them synthetically from touch. By switching the backdrop close logic to pointer events, the ghost-click is eliminated at the source rather than worked around with timing hacks.

## Test plan

- [ ] Open app on mobile, tap a note on first load — editor stays open
- [ ] Tap backdrop to close editor — works on both mobile and desktop
- [ ] Open formatting toolbar dropdown, click inside editor — dropdown closes
- [ ] Select text inside editor, drag outside to backdrop, release — editor stays open
