### PR TITLE
fix: make admin user deletion atomic and surface errors in UI

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -227,29 +227,53 @@ export function getUser(userId: number): User | null {
 }
 
 export async function deleteUser(userId: number): Promise<void> {
-	// Cascade: delete user's data in dependency order
-	sqlite.prepare('DELETE FROM user_preferences WHERE user_id = ?').run(userId);
-	sqlite.prepare('DELETE FROM api_keys WHERE user_id = ?').run(userId);
-	sqlite.prepare('DELETE FROM note_user_state WHERE user_id = ?').run(userId);
-	sqlite
-		.prepare('DELETE FROM note_collaborators WHERE user_id = ? OR added_by = ?')
-		.run(userId, userId);
-	sqlite.prepare('DELETE FROM sync_log WHERE user_id = ?').run(userId);
-	sqlite.prepare('DELETE FROM attachments WHERE user_id = ?').run(userId);
-	sqlite
-		.prepare(
-			'DELETE FROM shared_notes WHERE note_id IN (SELECT id FROM notes WHERE user_id = ?)'
-		)
-		.run(userId);
-	sqlite
-		.prepare(
-			'DELETE FROM note_tags WHERE note_id IN (SELECT id FROM notes WHERE user_id = ?)'
-		)
-		.run(userId);
-	sqlite.prepare('DELETE FROM notes WHERE user_id = ?').run(userId);
-	sqlite.prepare('DELETE FROM tags WHERE user_id = ?').run(userId);
-	sqlite.prepare('DELETE FROM sessions WHERE user_id = ?').run(userId);
-	db.delete(users).where(eq(users.id, userId)).run();
+	// Atomic cascade: all-or-nothing. Also clear rows from other users that
+	// reference the deleted user's notes (e.g. sync_log, note_user_state,
+	// note_collaborators) so foreign-key checks don't block the final delete.
+	const tx = sqlite.transaction((uid: number) => {
+		sqlite.prepare('DELETE FROM user_preferences WHERE user_id = ?').run(uid);
+		sqlite.prepare('DELETE FROM api_keys WHERE user_id = ?').run(uid);
+		sqlite
+			.prepare(
+				'DELETE FROM note_user_state WHERE user_id = ? OR note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid, uid);
+		sqlite
+			.prepare(
+				'DELETE FROM note_collaborators WHERE user_id = ? OR added_by = ? OR note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid, uid, uid);
+		sqlite
+			.prepare(
+				'DELETE FROM sync_log WHERE user_id = ? OR note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid, uid);
+		sqlite
+			.prepare(
+				'DELETE FROM attachments WHERE user_id = ? OR note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid, uid);
+		sqlite
+			.prepare(
+				'DELETE FROM shared_notes WHERE note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid);
+		sqlite
+			.prepare(
+				'DELETE FROM note_tags WHERE note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid);
+		sqlite
+			.prepare(
+				'DELETE FROM note_versions WHERE note_id IN (SELECT id FROM notes WHERE user_id = ?)'
+			)
+			.run(uid);
+		sqlite.prepare('DELETE FROM notes WHERE user_id = ?').run(uid);
+		sqlite.prepare('DELETE FROM tags WHERE user_id = ?').run(uid);
+		sqlite.prepare('DELETE FROM sessions WHERE user_id = ?').run(uid);
+		sqlite.prepare('DELETE FROM users WHERE id = ?').run(uid);
+	});
+	tx(userId);
 }
 
 export async function changePassword(

--- a/src/routes/(app)/settings/users/+page.svelte
+++ b/src/routes/(app)/settings/users/+page.svelte
@@ -70,9 +70,16 @@
 			const res = await fetch(`/api/admin/users/${userId}`, { method: 'DELETE' });
 			if (res.ok) {
 				users = users.filter((u) => u.id !== userId);
+				createMsg = 'User deleted';
+				createError = false;
+			} else {
+				const d = await res.json().catch(() => ({}));
+				createMsg = d.message || 'Failed to delete user';
+				createError = true;
 			}
 		} catch {
-			// ignore
+			createMsg = 'Connection error';
+			createError = true;
 		}
 	}
 
@@ -167,7 +174,10 @@
 
 		<div class="space-y-3">
 			{#each users as user (user.id)}
-				<div class="flex flex-col gap-2 rounded-sm border border-[var(--border-subtle)] p-4 sm:flex-row sm:items-center sm:justify-between">
+				<div
+					class="flex flex-col gap-2 rounded-sm border border-[var(--border-subtle)] p-4 sm:flex-row sm:items-center sm:justify-between"
+					data-testid="user-row-{user.id}"
+				>
 					<div class="min-w-0">
 						<p class="truncate font-medium text-[var(--text)]">
 							{user.displayName || user.email}
@@ -195,6 +205,7 @@
 							</button>
 							<button
 								onclick={() => deleteUser(user.id)}
+								data-testid="delete-user-btn-{user.id}"
 								class="rounded-sm px-3 py-1 text-xs text-[var(--destructive)] hover:bg-[var(--error-bg)]"
 							>
 								Delete

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from './helpers/fixtures.js';
 import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { TEST_CREDENTIALS_FILE } from './global-setup';
 
 const { userPassword } = JSON.parse(readFileSync(TEST_CREDENTIALS_FILE, 'utf-8'));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_IMAGE_PATH = join(__dirname, 'helpers', 'test-image.png');
 
 /** Create a victim user via the admin API, returning the user's id. */
 async function createVictim(
@@ -95,6 +100,25 @@ test.describe.serial('Admin — User Deletion', () => {
 			data: { title: 'Victim Note #todo', content: 'content #work' }
 		});
 		expect(noteRes.ok()).toBe(true);
+		const note = await noteRes.json();
+
+		// Upload an attachment on the note. Use a browser-context fetch so the
+		// Origin header is set correctly for SvelteKit's CSRF check.
+		const imageBase64 = readFileSync(TEST_IMAGE_PATH).toString('base64');
+		const attachmentStatus = await victimPage.evaluate(
+			async ({ noteId, base64 }) => {
+				const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+				const form = new FormData();
+				form.append('file', new Blob([bytes], { type: 'image/png' }), 'test-image.png');
+				const r = await fetch(`/api/notes/${noteId}/attachments`, {
+					method: 'POST',
+					body: form
+				});
+				return r.status;
+			},
+			{ noteId: note.id, base64: imageBase64 }
+		);
+		expect(attachmentStatus).toBe(201);
 
 		// Write a preference and create an API key to exercise every table
 		await victimPage.request.put('/api/preferences', {

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from './helpers/fixtures.js';
+import { readFileSync } from 'fs';
+import { TEST_CREDENTIALS_FILE } from './global-setup';
+
+const { userPassword } = JSON.parse(readFileSync(TEST_CREDENTIALS_FILE, 'utf-8'));
+
+/** Create a victim user via the admin API, returning the user's id. */
+async function createVictim(
+	page: import('@playwright/test').Page,
+	email: string,
+	displayName = email.split('@')[0]
+): Promise<number> {
+	const res = await page.request.post('/api/admin/users', {
+		data: { email, displayName, password: userPassword, role: 'user' }
+	});
+	expect(res.status()).toBe(201);
+	const user = await res.json();
+	return user.id;
+}
+
+test.describe.serial('Admin — User Deletion', () => {
+	test('Scenario: Admin deletes a user from the users list', async ({
+		authenticatedPage: page
+	}) => {
+		// Given a disposable user exists
+		const victimId = await createVictim(page, 'delete-me@test.com', 'Delete Me');
+
+		// When the admin navigates to the users settings page
+		await page.goto('/settings/users');
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByTestId(`user-row-${victimId}`)).toBeVisible();
+
+		// And accepts the confirmation dialog for deletion
+		page.once('dialog', (dialog) => dialog.accept());
+
+		const deleteResponse = page.waitForResponse(
+			(res) => res.url().endsWith(`/api/admin/users/${victimId}`) && res.request().method() === 'DELETE'
+		);
+		await page.getByTestId(`delete-user-btn-${victimId}`).click();
+		const res = await deleteResponse;
+
+		// Then the delete request succeeds
+		expect(res.status()).toBe(200);
+
+		// And the user disappears from the list
+		await expect(page.getByTestId(`user-row-${victimId}`)).toHaveCount(0);
+
+		// And the list is reloaded correctly on refresh (backend is consistent)
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByTestId(`user-row-${victimId}`)).toHaveCount(0);
+	});
+
+	test('Scenario: Deletion is cancelled when the admin dismisses the confirmation', async ({
+		authenticatedPage: page
+	}) => {
+		// Given a user exists
+		const victimId = await createVictim(page, 'keep-me@test.com', 'Keep Me');
+
+		// When the admin navigates to the users settings page
+		await page.goto('/settings/users');
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByTestId(`user-row-${victimId}`)).toBeVisible();
+
+		// And dismisses the confirmation dialog
+		page.once('dialog', (dialog) => dialog.dismiss());
+		await page.getByTestId(`delete-user-btn-${victimId}`).click();
+
+		// Then the user remains in the list
+		await expect(page.getByTestId(`user-row-${victimId}`)).toBeVisible();
+
+		// Clean up
+		await page.request.delete(`/api/admin/users/${victimId}`);
+	});
+
+	test('Scenario: Deleting a user with notes, tags, and attachments succeeds', async ({
+		authenticatedPage: page,
+		browser
+	}) => {
+		// Given a user with full data exists (note, tag, attachment, preferences, api key)
+		const email = 'heavy-user@test.com';
+		const victimId = await createVictim(page, email, 'Heavy User');
+
+		// Log in as the victim in a fresh context so they create their own data
+		const ctx = await browser.newContext();
+		const victimPage = await ctx.newPage();
+		await victimPage.goto('/login');
+		await victimPage.getByTestId('email-input').fill(email);
+		await victimPage.getByTestId('password-input').fill(userPassword);
+		await victimPage.getByTestId('login-btn').click();
+		await victimPage.waitForURL('/');
+
+		// Create a note with a tag
+		const noteRes = await victimPage.request.post('/api/notes', {
+			data: { title: 'Victim Note #todo', content: 'content #work' }
+		});
+		expect(noteRes.ok()).toBe(true);
+
+		// Write a preference and create an API key to exercise every table
+		await victimPage.request.put('/api/preferences', {
+			data: { defaultNoteMode: 'markdown' }
+		});
+		await victimPage.request.post('/api/settings/api-keys', { data: { name: 'test-key' } });
+
+		await ctx.close();
+
+		// When the admin deletes the user with all their data
+		await page.goto('/settings/users');
+		await page.waitForLoadState('networkidle');
+		await expect(page.getByTestId(`user-row-${victimId}`)).toBeVisible();
+
+		page.once('dialog', (dialog) => dialog.accept());
+		const deleteResponse = page.waitForResponse(
+			(res) => res.url().endsWith(`/api/admin/users/${victimId}`) && res.request().method() === 'DELETE'
+		);
+		await page.getByTestId(`delete-user-btn-${victimId}`).click();
+		const res = await deleteResponse;
+
+		// Then the delete succeeds atomically (no partial state)
+		expect(res.status()).toBe(200);
+		await expect(page.getByTestId(`user-row-${victimId}`)).toHaveCount(0);
+
+		// And the user cannot log in afterwards
+		const loginRes = await page.request.post('/api/auth/login', {
+			data: { email, password: userPassword }
+		});
+		expect(loginRes.status()).toBe(401);
+	});
+});


### PR DESCRIPTION
deleteUser() ran each child-table cleanup as a separate statement, so a
foreign-key violation on any step (e.g. sync_log rows from other users
referencing the deleted user's notes) would abort mid-way and leave the
database in a partial state. The API swallowed the error and the admin
page silently ignored the non-ok response, so clicking Delete and
confirming appeared to do nothing.

- Wrap the full cascade in a single sqlite transaction so the deletion
  is atomic.
- Also remove rows in sync_log, note_user_state, note_collaborators,
  note_versions, and attachments that belong to other users but
  reference the deleted user's notes, so the final DELETE FROM notes
  cannot trip a foreign-key check.
- Surface delete failures in the users settings UI instead of silently
  swallowing them.
- Add data-testids on the user row and delete button to support tests.
- Add e2e coverage for the admin user deletion flow (happy path,
  cancelled confirmation, and a user with notes / tags / attachments /
  preferences / api keys).

https://claude.ai/code/session_015T2HE6VzB64ZmSSyy1Wz4R