### PR TITLE
chore: pin pnpm via packageManager field for CI and tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:
@@ -37,8 +35,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:
@@ -68,8 +64,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.28.3",
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "license": "MIT",
   "author": "Bretzel (https://bretzel.app)",
   "homepage": "https://crumbs.bretzel.app",


### PR DESCRIPTION
Follow-up to #63.

#63 pins pnpm to 9 in the `Dockerfile`, fixing the Docker build. This PR closes the remaining gap: CI and tooling still floated on `pnpm@latest`, which resolves to pnpm 10+ and breaks native module builds (e.g. `better-sqlite3`) because pnpm 10 no longer runs dependency build scripts by default. Our `pnpm-lock.yaml` is `lockfileVersion: '9.0'`.

## Changes
- **`package.json`**: add `"packageManager": "pnpm@9.15.9"` — a single source of truth that both `corepack` and `pnpm/action-setup@v4` honor automatically.
- **`.github/workflows/ci.yml`** and **`screenshots.yml`**: drop `version: latest` from `pnpm/action-setup@v4` so it resolves the version from the `packageManager` field instead of pulling the floating latest.

## Notes
- `9.15.9` is the latest pnpm 9.x release.
- Does not touch the `Dockerfile`, so there's no conflict with #63. Once `packageManager` lands, the Dockerfile's `corepack prepare pnpm@9` could also be simplified to a plain `corepack enable` in a later cleanup if desired.

https://claude.ai/code/session_01BMkphTAD8S4vPBpPLufVZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMkphTAD8S4vPBpPLufVZT)_