### PR TITLE
fix(editor): avoid mobile focus on task checkboxes

### DIFF
--- a/src/lib/components/TiptapEditor.svelte
+++ b/src/lib/components/TiptapEditor.svelte
@@ -27,6 +27,54 @@
 	let element: HTMLDivElement | undefined = $state();
 	let editor: Editor | undefined = $state();
 
+	function isTaskCheckboxTarget(target: EventTarget | null): boolean {
+		if (target instanceof Element) {
+			const checkbox = target.matches('input[type="checkbox"]')
+				? target
+				: target.closest('label')?.querySelector('input[type="checkbox"]');
+			return checkbox !== null && checkbox !== undefined;
+		}
+		return false;
+	}
+
+	function isTouchDevice(): boolean {
+		return window.matchMedia('(pointer: coarse)').matches || navigator.maxTouchPoints > 0;
+	}
+
+	function handleWrapperPointerDown(event: PointerEvent) {
+		if (event.pointerType === 'touch' && isTaskCheckboxTarget(event.target)) {
+			event.preventDefault();
+		}
+	}
+
+	function handleWrapperClick(event: MouseEvent) {
+		if (isTaskCheckboxTarget(event.target)) {
+			return;
+		}
+
+		editor?.commands.focus();
+	}
+
+	function handleWrapperChangeCapture(event: Event) {
+		if (!isTouchDevice() || !(event.target instanceof HTMLInputElement)) return;
+		if (event.target.type !== 'checkbox' || !editor) return;
+
+		const taskItem = event.target.closest('li[data-checked]');
+		if (!taskItem) return;
+
+		const taskItemPosition = editor.view.posAtDOM(taskItem, 0) - 1;
+		const taskItemNode = editor.state.doc.nodeAt(taskItemPosition);
+		if (taskItemNode?.type.name !== 'taskItem') return;
+
+		event.stopPropagation();
+		editor.view.dispatch(
+			editor.state.tr.setNodeMarkup(taskItemPosition, undefined, {
+				...taskItemNode.attrs,
+				checked: event.target.checked
+			})
+		);
+	}
+
 	onMount(() => {
 		editor = new Editor({
 			element: element!,
@@ -77,7 +125,9 @@
 	role="textbox"
 	aria-multiline="true"
 	tabindex="0"
-	onclick={() => editor?.commands.focus()}
+	onpointerdown={handleWrapperPointerDown}
+	onclick={handleWrapperClick}
+	onchangecapture={handleWrapperChangeCapture}
 ></div>
 
 <style>

--- a/tests/e2e/formatting.spec.ts
+++ b/tests/e2e/formatting.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, noteCard } from './helpers/fixtures.js';
-import type { Page } from '@playwright/test';
+import { devices, type Page } from '@playwright/test';
 
 /** Run a TipTap command chain via the exposed editor instance on the DOM element */
 async function runTiptapCommand(page: Page, commandFn: string) {
@@ -107,5 +107,51 @@ test.describe('Rich text formatting', () => {
 		await expect(page.getByTestId('note-content-input')).toBeVisible();
 		await expect(page.getByTestId('tiptap-editor')).not.toBeVisible();
 		await expect(page.getByTestId('note-content-input')).toHaveValue('Hello **bold** world');
+	});
+});
+
+test.describe('Rich text formatting on mobile', () => {
+	const pixel7 = devices['Pixel 7'];
+	test.use({
+		viewport: pixel7.viewport,
+		userAgent: pixel7.userAgent,
+		deviceScaleFactor: pixel7.deviceScaleFactor,
+		isMobile: pixel7.isMobile,
+		hasTouch: pixel7.hasTouch
+	});
+
+	test('Scenario: Tapping a task-list checkbox does not focus the editor', async ({ authenticatedPage: page }) => {
+		// Given a regular text note contains a task list in the rich-text editor
+		await page.getByTestId('new-note-fab').click();
+		await page.getByTestId('mobile-overflow-menu-btn').click();
+		await page.getByTestId('markdown-toggle').click();
+		await page.getByTestId('note-content-input').fill('- [ ] Mobile task');
+		await page.getByTestId('mobile-overflow-menu-btn').click();
+		await page.getByTestId('markdown-toggle').click();
+
+		const richTextEditor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		const checkbox = richTextEditor.locator('input[type="checkbox"]');
+		await expect(checkbox).not.toBeChecked();
+		await expect(richTextEditor).not.toBeFocused();
+		await richTextEditor.evaluate((element) => {
+			element.dataset.focusCount = '0';
+			element.addEventListener('focus', () => {
+				element.dataset.focusCount = String(Number(element.dataset.focusCount) + 1);
+			});
+		});
+
+		// When the checkbox is tapped, only its state changes and focus never enters the editor
+		await checkbox.tap();
+
+		await expect(checkbox).toBeChecked();
+		await expect(richTextEditor).not.toBeFocused();
+		await expect(richTextEditor).toHaveAttribute('data-focus-count', '0');
+
+		// And unchecking it also leaves the contenteditable editor unfocused
+		await checkbox.tap();
+
+		await expect(checkbox).not.toBeChecked();
+		await expect(richTextEditor).not.toBeFocused();
+		await expect(richTextEditor).toHaveAttribute('data-focus-count', '0');
 	});
 });

--- a/tests/e2e/formatting.spec.ts
+++ b/tests/e2e/formatting.spec.ts
@@ -13,6 +13,29 @@ async function runTiptapCommand(page: Page, commandFn: string) {
 	);
 }
 
+/**
+ * Read the `checked` attribute of the first task item from the live ProseMirror
+ * document. This reflects the editor's document state, not just the native
+ * checkbox widget — so it catches a widget/document desync where the DOM
+ * checkbox toggles but the transaction never updates the node.
+ */
+async function firstTaskItemChecked(page: Page): Promise<boolean> {
+	return page.getByTestId('tiptap-editor').evaluate((el) => {
+		const editor = (el as any).__tiptapEditor;
+		if (!editor) throw new Error('TipTap editor not found on element');
+		let checked: boolean | undefined;
+		editor.state.doc.descendants((node: any) => {
+			if (checked === undefined && node.type.name === 'taskItem') {
+				checked = Boolean(node.attrs.checked);
+				return false;
+			}
+			return true;
+		});
+		if (checked === undefined) throw new Error('No task item found in document');
+		return checked;
+	});
+}
+
 /** Toggle markdown mode via the overflow menu. */
 async function toggleMarkdownMode(page: Page) {
 	await page.getByTestId('overflow-menu-btn').click();
@@ -140,17 +163,20 @@ test.describe('Rich text formatting on mobile', () => {
 			});
 		});
 
-		// When the checkbox is tapped, only its state changes and focus never enters the editor
+		// When the checkbox is tapped, the change propagates to the editor's document
+		// without focus ever entering the editor (which would open the mobile keyboard)
 		await checkbox.tap();
 
 		await expect(checkbox).toBeChecked();
+		expect(await firstTaskItemChecked(page)).toBe(true);
 		await expect(richTextEditor).not.toBeFocused();
 		await expect(richTextEditor).toHaveAttribute('data-focus-count', '0');
 
-		// And unchecking it also leaves the contenteditable editor unfocused
+		// And unchecking propagates to the document too, still without focusing the editor
 		await checkbox.tap();
 
 		await expect(checkbox).not.toBeChecked();
+		expect(await firstTaskItemChecked(page)).toBe(false);
 		await expect(richTextEditor).not.toBeFocused();
 		await expect(richTextEditor).toHaveAttribute('data-focus-count', '0');
 	});


### PR DESCRIPTION
## Summary

Intercept touch checkbox changes before TipTap's focusing handler and update the task-item transaction directly. This prevents the mobile keyboard from starting to open while preserving checkbox state changes.

Strengthen the mobile regression test to assert that checking and unchecking emit no editor focus events.

## Screenshots

See current behavior:
https://github.com/user-attachments/assets/1e562aab-2f8e-4120-a4fc-8e2df1a9ae86

And new behavior from this PR:
https://github.com/user-attachments/assets/2aa3db18-6129-4ce5-84ab-2346ca568981
