### PR TITLE
fix(sync): merge concurrent note content edits

### DIFF
--- a/src/lib/server/notes-service.test.ts
+++ b/src/lib/server/notes-service.test.ts
@@ -263,6 +263,31 @@ describe('updateNote', () => {
 		const updated = updateNote(db, OWNER_ID, 'n1', { title: 'Now with #newtag' });
 		expect(updated!.tags).toContain('newtag');
 	});
+
+	it('should merge concurrent content edits using the snapshot created by the first update', () => {
+		seedNote('n1', {
+			title: 'Shopping',
+			content: '- [ ] Milk\n- [ ] Bread',
+			checklistMode: true,
+			version: 1
+		});
+		shareNote('n1');
+
+		const ownerUpdate = updateNote(db, OWNER_ID, 'n1', {
+			content: '- [ ] Milk\n- [x] Bread',
+			baseVersion: 1
+		});
+		expect(ownerUpdate!.version).toBe(2);
+
+		const collabUpdate = updateNote(db, COLLAB_ID, 'n1', {
+			content: '- [x] Milk\n- [ ] Bread',
+			baseVersion: 1
+		});
+
+		expect(collabUpdate!.content).toBe('- [x] Milk\n- [x] Bread');
+		const snapshots = db.select().from(noteVersions).where(eq(noteVersions.noteId, 'n1')).all();
+		expect(snapshots.some((snapshot) => snapshot.version === 1)).toBe(true);
+	});
 });
 
 describe('deleteNote', () => {

--- a/src/lib/server/notes-service.test.ts
+++ b/src/lib/server/notes-service.test.ts
@@ -288,6 +288,21 @@ describe('updateNote', () => {
 		const snapshots = db.select().from(noteVersions).where(eq(noteVersions.noteId, 'n1')).all();
 		expect(snapshots.some((snapshot) => snapshot.version === 1)).toBe(true);
 	});
+
+	it('should keep the incoming edit when a metadata-only bump left no base snapshot', () => {
+		seedNote('n1', { title: 'Note', content: 'hello', version: 1 });
+
+		// A metadata-only change bumps the version but creates no snapshot.
+		updateNote(db, OWNER_ID, 'n1', { pinned: true });
+		const snapshots = db.select().from(noteVersions).where(eq(noteVersions.noteId, 'n1')).all();
+		expect(snapshots).toHaveLength(0);
+
+		// A later concurrent content edit based on the pre-bump version therefore has
+		// no base to merge against — the incoming edit must be preserved, not dropped.
+		const edited = updateNote(db, OWNER_ID, 'n1', { content: 'hello world', baseVersion: 1 });
+
+		expect(edited!.content).toBe('hello world');
+	});
 });
 
 describe('deleteNote', () => {

--- a/src/lib/server/notes-service.ts
+++ b/src/lib/server/notes-service.ts
@@ -1,6 +1,6 @@
 import type { Db } from './db/index.js';
-import { notes, noteTags, tags, noteCollaborators, noteUserState, noteVersions } from './db/schema.js';
-import { eq, and, desc, like, or, inArray, sql, lte } from 'drizzle-orm';
+import { notes, noteTags, tags, noteCollaborators, noteUserState } from './db/schema.js';
+import { eq, and, like, or, inArray, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { extractTags } from '$lib/utils/tags.js';
 import { fetchTagsForNotes, syncNoteTags } from './tags.js';
@@ -8,7 +8,7 @@ import { fetchAttachmentsForNotes } from './attachments.js';
 import { fetchCollaboratorsForNotes } from './collaborators.js';
 import { fetchSharesForNotes } from './shares-service.js';
 import { canAccessNote } from './api-utils.js';
-import { createSnapshot } from './versions-service.js';
+import { createSnapshot, getBaseContent } from './versions-service.js';
 import { mergeContentUpdate } from '$lib/utils/content-merge.js';
 import type { NoteFilter } from '$lib/types/index.js';
 
@@ -214,19 +214,6 @@ export interface UpdateNoteInput {
 
 /** Per-user fields that go to noteUserState for collaborators */
 const PER_USER_FIELDS = ['pinned', 'archived', 'sortOrder'] as const;
-
-function getBaseContent(db: Db, noteId: string, baseVersion: number | undefined): string | null {
-	if (baseVersion === undefined) return null;
-
-	const snapshot = db.select({ content: noteVersions.content })
-		.from(noteVersions)
-		.where(and(eq(noteVersions.noteId, noteId), lte(noteVersions.version, baseVersion)))
-		.orderBy(desc(noteVersions.version))
-		.limit(1)
-		.get();
-
-	return snapshot?.content ?? null;
-}
 
 export function updateNote(db: Db, userId: number, id: string, input: UpdateNoteInput) {
 	const { canAccess, isOwner } = canAccessNote(db, id, userId);

--- a/src/lib/server/notes-service.ts
+++ b/src/lib/server/notes-service.ts
@@ -9,7 +9,7 @@ import { fetchCollaboratorsForNotes } from './collaborators.js';
 import { fetchSharesForNotes } from './shares-service.js';
 import { canAccessNote } from './api-utils.js';
 import { createSnapshot } from './versions-service.js';
-import { mergeContent } from '$lib/utils/content-merge.js';
+import { mergeContentUpdate } from '$lib/utils/content-merge.js';
 import type { NoteFilter } from '$lib/types/index.js';
 
 interface NoteRow {
@@ -215,6 +215,19 @@ export interface UpdateNoteInput {
 /** Per-user fields that go to noteUserState for collaborators */
 const PER_USER_FIELDS = ['pinned', 'archived', 'sortOrder'] as const;
 
+function getBaseContent(db: Db, noteId: string, baseVersion: number | undefined): string | null {
+	if (baseVersion === undefined) return null;
+
+	const snapshot = db.select({ content: noteVersions.content })
+		.from(noteVersions)
+		.where(and(eq(noteVersions.noteId, noteId), lte(noteVersions.version, baseVersion)))
+		.orderBy(desc(noteVersions.version))
+		.limit(1)
+		.get();
+
+	return snapshot?.content ?? null;
+}
+
 export function updateNote(db: Db, userId: number, id: string, input: UpdateNoteInput) {
 	const { canAccess, isOwner } = canAccessNote(db, id, userId);
 	if (!canAccess) return null;
@@ -238,29 +251,18 @@ export function updateNote(db: Db, userId: number, id: string, input: UpdateNote
 
 	if (input.title !== undefined) { sharedUpdates.title = input.title; hasSharedUpdates = true; }
 	if (input.content !== undefined) {
-		// 3-way merge to preserve concurrent edits from other users.
-		// Only attempt merge when there's a concurrent edit: the client's
-		// baseVersion is behind the current version, meaning someone else
-		// saved between the client's load and this save.
+		// Preserve concurrent edits at line/block granularity when the client
+		// saved from an older note version.
 		const hasConcurrentEdit = input.baseVersion !== undefined
 			&& input.baseVersion < existing.version;
 
-		if (hasConcurrentEdit && input.content !== existing.content) {
-			const baseSnapshot = db.select({ content: noteVersions.content })
-				.from(noteVersions)
-				.where(and(eq(noteVersions.noteId, id), lte(noteVersions.version, input.baseVersion!)))
-				.orderBy(desc(noteVersions.version))
-				.limit(1)
-				.get();
-
-			if (baseSnapshot && baseSnapshot.content !== existing.content) {
-				sharedUpdates.content = mergeContent(baseSnapshot.content, input.content, existing.content);
-			} else {
-				sharedUpdates.content = input.content;
-			}
-		} else {
-			sharedUpdates.content = input.content;
-		}
+		sharedUpdates.content = hasConcurrentEdit
+			? mergeContentUpdate({
+				baseContent: getBaseContent(db, id, input.baseVersion),
+				incomingContent: input.content,
+				currentContent: existing.content
+			})
+			: input.content;
 		hasSharedUpdates = true;
 	}
 	if (input.color !== undefined) { sharedUpdates.color = input.color; hasSharedUpdates = true; }
@@ -276,6 +278,22 @@ export function updateNote(db: Db, userId: number, id: string, input: UpdateNote
 			hasSharedUpdates = true;
 		}
 		if (input.sortOrder !== undefined) { sharedUpdates.sortOrder = input.sortOrder; hasSharedUpdates = true; }
+	}
+
+	const hasActualContentChange =
+		(input.title !== undefined && input.title !== existing.title) ||
+		(sharedUpdates.content !== undefined && sharedUpdates.content !== existing.content) ||
+		(input.color !== undefined && input.color !== existing.color) ||
+		(input.checklistMode !== undefined && input.checklistMode !== existing.checklistMode);
+
+	if (hasActualContentChange) {
+		createSnapshot(db, id, {
+			version: existing.version,
+			title: existing.title,
+			content: existing.content,
+			checklistMode: existing.checklistMode,
+			color: existing.color
+		});
 	}
 
 	if (hasSharedUpdates || isOwner) {
@@ -322,23 +340,6 @@ export function updateNote(db: Db, userId: number, id: string, input: UpdateNote
 			const extractedTags = extractTags(content);
 			syncNoteTags(db, id, extractedTags, existing.userId);
 		}
-	}
-
-	// Create a version snapshot only when at least one content field actually changed
-	const hasActualContentChange =
-		(input.title !== undefined && input.title !== existing.title) ||
-		(input.content !== undefined && input.content !== existing.content) ||
-		(input.color !== undefined && input.color !== existing.color) ||
-		(input.checklistMode !== undefined && input.checklistMode !== existing.checklistMode);
-
-	if (hasActualContentChange) {
-		createSnapshot(db, id, {
-			version: existing.version,
-			title: existing.title,
-			content: existing.content,
-			checklistMode: existing.checklistMode,
-			color: existing.color
-		});
 	}
 
 	return getNote(db, userId, id);

--- a/src/lib/server/versions-service.test.ts
+++ b/src/lib/server/versions-service.test.ts
@@ -3,7 +3,7 @@ import { createTestDb } from './db/test-helpers.js';
 import { users, notes, noteVersions } from './db/schema.js';
 import { eq } from 'drizzle-orm';
 import type { Db } from './db/index.js';
-import { createSnapshot, listVersions, getVersion, snapshotCurrentNote } from './versions-service.js';
+import { createSnapshot, listVersions, getVersion, snapshotCurrentNote, getBaseContent } from './versions-service.js';
 
 let db: Db;
 
@@ -42,6 +42,32 @@ function seedNote(overrides: Partial<typeof notes.$inferInsert> = {}) {
 beforeEach(() => {
 	({ db } = createTestDb());
 	seedUser();
+});
+
+describe('getBaseContent', () => {
+	it('returns null when the base version is unknown', () => {
+		seedNote();
+		expect(getBaseContent(db, NOTE_ID, undefined)).toBeNull();
+	});
+
+	it('returns the snapshot content at or before the base version', () => {
+		seedNote();
+		createSnapshot(db, NOTE_ID, { version: 1, title: 'T', content: 'v1', checklistMode: false, color: 'default' });
+		createSnapshot(db, NOTE_ID, { version: 3, title: 'T', content: 'v3', checklistMode: false, color: 'default' });
+
+		expect(getBaseContent(db, NOTE_ID, 2)).toBe('v1');
+		expect(getBaseContent(db, NOTE_ID, 3)).toBe('v3');
+	});
+
+	it('returns null instead of a newer snapshot when none exists at or before the base version', () => {
+		seedNote();
+		// Only a snapshot NEWER than the requested base exists (e.g. the real base was
+		// pruned). Using it as the merge base would treat unseen lines as deletions,
+		// so getBaseContent must return null rather than fall back to it.
+		createSnapshot(db, NOTE_ID, { version: 5, title: 'T', content: 'v5', checklistMode: false, color: 'default' });
+
+		expect(getBaseContent(db, NOTE_ID, 2)).toBeNull();
+	});
 });
 
 describe('createSnapshot', () => {

--- a/src/lib/server/versions-service.ts
+++ b/src/lib/server/versions-service.ts
@@ -7,12 +7,15 @@ import type { NoteVersion, NoteVersionSummary, NoteColor } from '$lib/types/inde
 const MAX_VERSIONS_PER_NOTE = 50;
 const CONTENT_PREVIEW_LENGTH = 80;
 
+type Transaction = Parameters<Parameters<Db['transaction']>[0]>[0];
+type SnapshotDb = Db | Transaction;
+
 /**
  * Create a snapshot of a note's current state.
  * Only called when content actually changed. Prunes snapshots beyond MAX_VERSIONS_PER_NOTE.
  */
 export function createSnapshot(
-db: Db,
+db: SnapshotDb,
 noteId: string,
 snapshot: {
 version: number;

--- a/src/lib/server/versions-service.ts
+++ b/src/lib/server/versions-service.ts
@@ -1,14 +1,39 @@
 import type { Db } from './db/index.js';
 import { noteVersions, notes } from './db/schema.js';
-import { eq, and, desc } from 'drizzle-orm';
+import { eq, and, desc, lte } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import type { NoteVersion, NoteVersionSummary, NoteColor } from '$lib/types/index.js';
 
 const MAX_VERSIONS_PER_NOTE = 50;
 const CONTENT_PREVIEW_LENGTH = 80;
 
-type Transaction = Parameters<Parameters<Db['transaction']>[0]>[0];
-type SnapshotDb = Db | Transaction;
+export type Transaction = Parameters<Parameters<Db['transaction']>[0]>[0];
+export type SnapshotDb = Db | Transaction;
+
+/**
+ * Resolve the 3-way merge base for a concurrent edit: the content of the snapshot
+ * at or before the client's base version. Returns null when the base version is
+ * unknown or no snapshot at/before it exists. Callers must NOT substitute a newer
+ * snapshot as the base — a base newer than what the client actually saw makes the
+ * merge treat other users' lines as deletions and silently drop them.
+ */
+export function getBaseContent(
+	db: SnapshotDb,
+	noteId: string,
+	baseVersion: number | undefined
+): string | null {
+	if (baseVersion === undefined) return null;
+
+	const snapshot = db
+		.select({ content: noteVersions.content })
+		.from(noteVersions)
+		.where(and(eq(noteVersions.noteId, noteId), lte(noteVersions.version, baseVersion)))
+		.orderBy(desc(noteVersions.version))
+		.limit(1)
+		.get();
+
+	return snapshot?.content ?? null;
+}
 
 /**
  * Create a snapshot of a note's current state.

--- a/src/lib/sync/server.test.ts
+++ b/src/lib/sync/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createTestDb } from '../server/db/test-helpers.js';
-import { notes, noteCollaborators, noteUserState, users, syncLog } from '../server/db/schema.js';
+import { notes, noteCollaborators, noteUserState, users, syncLog, noteVersions } from '../server/db/schema.js';
 import { eq, and } from 'drizzle-orm';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schema from '../server/db/schema.js';
@@ -287,6 +287,64 @@ describe('processSyncPush — shared notes', () => {
 		const note = db.select().from(notes).where(eq(notes.id, 'n1')).get()!;
 		// Both changes should be merged: Milk checked by collab, Bread checked by owner
 		expect(note.content).toBe('- [x] Milk\n- [x] Bread');
+	});
+
+	it('should create a base snapshot during sync so later queued edits can merge', async () => {
+		const t1 = new Date('2024-01-01T00:00:00Z');
+		seedSharedNote('n1', {
+			updatedAt: t1,
+			createdAt: t1,
+			content: '- [ ] Milk\n- [ ] Bread',
+			checklistMode: true,
+			version: 1
+		});
+
+		await processSyncPush(db, [{
+			noteId: 'n1',
+			operation: 'update',
+			timestamp: t1.getTime() + 1000,
+			data: { content: '- [ ] Milk\n- [x] Bread' },
+			baseVersion: 1
+		}], OWNER_ID);
+
+		await processSyncPush(db, [{
+			noteId: 'n1',
+			operation: 'update',
+			timestamp: t1.getTime() + 2000,
+			data: { content: '- [x] Milk\n- [ ] Bread' },
+			baseVersion: 1
+		}], COLLAB_ID);
+
+		const note = db.select().from(notes).where(eq(notes.id, 'n1')).get()!;
+		expect(note.content).toBe('- [x] Milk\n- [x] Bread');
+
+		const snapshots = db.select().from(noteVersions).where(eq(noteVersions.noteId, 'n1')).all();
+		expect(snapshots.some((snapshot) => snapshot.version === 1)).toBe(true);
+	});
+
+	it('should retain at most 50 snapshots created by sync updates', async () => {
+		const createdAt = new Date('2024-01-01T00:00:00Z');
+		seedSharedNote('n1', {
+			updatedAt: createdAt,
+			createdAt,
+			content: 'version 1',
+			version: 1
+		});
+
+		for (let version = 2; version <= 52; version++) {
+			await processSyncPush(db, [{
+				noteId: 'n1',
+				operation: 'update',
+				timestamp: createdAt.getTime() + version,
+				data: { content: `version ${version}` },
+				baseVersion: version - 1
+			}], OWNER_ID);
+		}
+
+		const snapshots = db.select().from(noteVersions).where(eq(noteVersions.noteId, 'n1')).all();
+		expect(snapshots).toHaveLength(50);
+		expect(snapshots.some((snapshot) => snapshot.version === 1)).toBe(false);
+		expect(snapshots.some((snapshot) => snapshot.version === 51)).toBe(true);
 	});
 
 	it('should not allow non-collaborator to update the note', async () => {

--- a/src/lib/sync/server.ts
+++ b/src/lib/sync/server.ts
@@ -1,10 +1,10 @@
 import type { Db } from '$lib/server/db/index.js';
 import { notes, noteCollaborators, noteUserState, noteVersions, syncLog } from '$lib/server/db/schema.js';
-import { eq, gt, and, or, sql, desc, lte } from 'drizzle-orm';
+import { eq, gt, and, sql, desc, lte } from 'drizzle-orm';
 import { extractTags } from '$lib/utils/tags.js';
 import { syncNoteTags } from '$lib/server/tags.js';
-import { canAccessNote } from '$lib/server/api-utils.js';
-import { mergeContent } from '$lib/utils/content-merge.js';
+import { createSnapshot } from '$lib/server/versions-service.js';
+import { mergeContentUpdate } from '$lib/utils/content-merge.js';
 import type { SyncQueueItem } from './idb.js';
 
 /**
@@ -69,16 +69,17 @@ export async function processSyncPush(db: Db, changes: SyncQueueItem[], userId: 
 						if (change.data.color !== undefined) sharedData.color = change.data.color;
 						if (change.data.checklistMode !== undefined) sharedData.checklistMode = change.data.checklistMode;
 
-						// Content: 3-way merge to preserve concurrent edits from other users
+						// Content: merge only when the client saved from an older note version.
 						if (change.data.content !== undefined && change.data.content !== note.content) {
-							const baseContent = getBaseContent(tx, change.noteId, change.baseVersion);
-							if (baseContent !== null && baseContent !== note.content) {
-								// 3-way merge: base, incoming (local), server current (remote)
-								sharedData.content = mergeContent(baseContent, change.data.content, note.content);
-							} else {
-								// No base or base matches server — take incoming content
-								sharedData.content = change.data.content;
-							}
+							const hasConcurrentEdit = change.baseVersion !== undefined
+								&& change.baseVersion < note.version;
+							sharedData.content = hasConcurrentEdit
+								? mergeContentUpdate({
+									baseContent: getBaseContent(tx, change.noteId, change.baseVersion),
+									incomingContent: change.data.content,
+									currentContent: note.content
+								})
+								: change.data.content;
 						}
 
 						if (isOwner) {
@@ -90,6 +91,22 @@ export async function processSyncPush(db: Db, changes: SyncQueueItem[], userId: 
 								sharedData.trashedAt = change.data.trashed ? new Date(change.timestamp) : null;
 							}
 							if (change.data.sortOrder !== undefined) sharedData.sortOrder = change.data.sortOrder;
+						}
+
+						const hasActualContentChange =
+							(change.data.title !== undefined && change.data.title !== note.title) ||
+							(sharedData.content !== undefined && sharedData.content !== note.content) ||
+							(change.data.color !== undefined && change.data.color !== note.color) ||
+							(change.data.checklistMode !== undefined && change.data.checklistMode !== note.checklistMode);
+
+						if (hasActualContentChange) {
+							createSnapshot(tx, change.noteId, {
+								version: note.version,
+								title: note.title,
+								content: note.content,
+								checklistMode: note.checklistMode,
+								color: note.color
+							});
 						}
 
 						tx.update(notes)

--- a/src/lib/sync/server.ts
+++ b/src/lib/sync/server.ts
@@ -1,36 +1,11 @@
 import type { Db } from '$lib/server/db/index.js';
-import { notes, noteCollaborators, noteUserState, noteVersions, syncLog } from '$lib/server/db/schema.js';
-import { eq, gt, and, sql, desc, lte } from 'drizzle-orm';
+import { notes, noteCollaborators, noteUserState, syncLog } from '$lib/server/db/schema.js';
+import { eq, gt, and, sql } from 'drizzle-orm';
 import { extractTags } from '$lib/utils/tags.js';
 import { syncNoteTags } from '$lib/server/tags.js';
-import { createSnapshot } from '$lib/server/versions-service.js';
+import { createSnapshot, getBaseContent } from '$lib/server/versions-service.js';
 import { mergeContentUpdate } from '$lib/utils/content-merge.js';
 import type { SyncQueueItem } from './idb.js';
-
-/**
- * Find the base content for 3-way merge from version snapshots.
- * Returns the content from the snapshot at or before the given version,
- * or the current note content if no snapshot is found.
- */
-function getBaseContent(tx: Parameters<Parameters<Db['transaction']>[0]>[0], noteId: string, baseVersion?: number): string | null {
-	if (baseVersion !== undefined) {
-		const snapshot = tx.select({ content: noteVersions.content })
-			.from(noteVersions)
-			.where(and(eq(noteVersions.noteId, noteId), lte(noteVersions.version, baseVersion)))
-			.orderBy(desc(noteVersions.version))
-			.limit(1)
-			.get();
-		if (snapshot) return snapshot.content;
-	}
-	// Fallback: get the most recent snapshot before the current version
-	const latest = tx.select({ content: noteVersions.content })
-		.from(noteVersions)
-		.where(eq(noteVersions.noteId, noteId))
-		.orderBy(desc(noteVersions.version))
-		.limit(1)
-		.get();
-	return latest?.content ?? null;
-}
 
 /**
  * Process incoming sync changes from client.

--- a/src/lib/utils/content-merge.test.ts
+++ b/src/lib/utils/content-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeContent, mergeContentTwoWay, mergeContentUpdate } from './content-merge.js';
+import { mergeContent, mergeContentUpdate } from './content-merge.js';
 
 describe('mergeContent (3-way)', () => {
 	it('should return remote when local is unchanged', () => {
@@ -89,24 +89,6 @@ describe('mergeContent (3-way)', () => {
 	});
 });
 
-describe('mergeContentTwoWay', () => {
-	it('should return remote when both are identical', () => {
-		expect(mergeContentTwoWay('hello', 'hello')).toBe('hello');
-	});
-
-	it('should preserve the current server document when contents differ', () => {
-		const local = '- [x] Milk\n- [ ] Bread';
-		const remote = '- [ ] Milk\n- [ ] Bread\n- [ ] Eggs';
-
-		expect(mergeContentTwoWay(local, remote)).toBe(remote);
-	});
-
-	it('should not resurrect content deleted from the current document', () => {
-		expect(mergeContentTwoWay('deleted content', '')).toBe('');
-	});
-});
-
-
 describe('mergeContentUpdate', () => {
 	it('should merge an incoming update against current content when a base is available', () => {
 		const result = mergeContentUpdate({
@@ -118,13 +100,45 @@ describe('mergeContentUpdate', () => {
 		expect(result).toBe('- [x] Milk\n- [x] Bread');
 	});
 
-	it('should preserve current content when the base is missing', () => {
+	it('should keep the incoming edit when no base snapshot is available', () => {
+		// Without a common ancestor a 3-way merge is impossible; dropping the
+		// incoming edit would silently lose the user's changes.
 		const result = mergeContentUpdate({
 			baseContent: null,
 			incomingContent: '- [x] Milk',
 			currentContent: '- [ ] Bread'
 		});
 
-		expect(result).toBe('- [ ] Bread');
+		expect(result).toBe('- [x] Milk');
+	});
+
+	it('should keep current content when the incoming edit equals it', () => {
+		const result = mergeContentUpdate({
+			baseContent: null,
+			incomingContent: 'same',
+			currentContent: 'same'
+		});
+
+		expect(result).toBe('same');
+	});
+
+	it('should keep current content when the incoming edit matches the base (no local change)', () => {
+		const result = mergeContentUpdate({
+			baseContent: 'base',
+			incomingContent: 'base',
+			currentContent: 'server changed'
+		});
+
+		expect(result).toBe('server changed');
+	});
+
+	it('should take the incoming edit when the server is unchanged from the base', () => {
+		const result = mergeContentUpdate({
+			baseContent: 'base',
+			incomingContent: 'incoming change',
+			currentContent: 'base'
+		});
+
+		expect(result).toBe('incoming change');
 	});
 });

--- a/src/lib/utils/content-merge.test.ts
+++ b/src/lib/utils/content-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { mergeContent, mergeContentTwoWay } from './content-merge.js';
+import { mergeContent, mergeContentTwoWay, mergeContentUpdate } from './content-merge.js';
 
 describe('mergeContent (3-way)', () => {
 	it('should return remote when local is unchanged', () => {
@@ -94,12 +94,37 @@ describe('mergeContentTwoWay', () => {
 		expect(mergeContentTwoWay('hello', 'hello')).toBe('hello');
 	});
 
-	it('should attempt merge when contents differ', () => {
+	it('should preserve the current server document when contents differ', () => {
 		const local = '- [x] Milk\n- [ ] Bread';
 		const remote = '- [ ] Milk\n- [ ] Bread\n- [ ] Eggs';
 
-		const result = mergeContentTwoWay(local, remote);
-		// Without a base, conflict resolution prefers remote
-		expect(result).toContain('- [ ] Bread');
+		expect(mergeContentTwoWay(local, remote)).toBe(remote);
+	});
+
+	it('should not resurrect content deleted from the current document', () => {
+		expect(mergeContentTwoWay('deleted content', '')).toBe('');
+	});
+});
+
+
+describe('mergeContentUpdate', () => {
+	it('should merge an incoming update against current content when a base is available', () => {
+		const result = mergeContentUpdate({
+			baseContent: '- [ ] Milk\n- [ ] Bread',
+			incomingContent: '- [x] Milk\n- [ ] Bread',
+			currentContent: '- [ ] Milk\n- [x] Bread'
+		});
+
+		expect(result).toBe('- [x] Milk\n- [x] Bread');
+	});
+
+	it('should preserve current content when the base is missing', () => {
+		const result = mergeContentUpdate({
+			baseContent: null,
+			incomingContent: '- [x] Milk',
+			currentContent: '- [ ] Bread'
+		});
+
+		expect(result).toBe('- [ ] Bread');
 	});
 });

--- a/src/lib/utils/content-merge.ts
+++ b/src/lib/utils/content-merge.ts
@@ -79,10 +79,31 @@ export function mergeContent(base: string, local: string, remote: string): strin
 
 /**
  * 2-way merge fallback when no base is available.
- * Uses an empty string as the base, so all lines from both sides appear
- * as additions. For conflicts (same region), prefers remote.
+ * Without a common ancestor, edits and deletions cannot be distinguished from
+ * concurrent changes. Preserve the current server document rather than
+ * fabricating content by combining two complete snapshots.
  */
 export function mergeContentTwoWay(local: string, remote: string): string {
-	if (local === remote) return remote;
-	return mergeContent('', local, remote);
+	return remote;
+}
+
+/**
+ * Merge an incoming content snapshot into the current server content.
+ * Uses 3-way merge when a base is available; otherwise falls back to a
+ * conservative 2-way merge instead of replacing the whole document.
+ */
+export function mergeContentUpdate(input: {
+	baseContent: string | null;
+	incomingContent: string;
+	currentContent: string;
+}): string {
+	const { baseContent, incomingContent, currentContent } = input;
+
+	if (incomingContent === currentContent) return currentContent;
+	if (baseContent === incomingContent) return currentContent;
+	if (baseContent === currentContent) return incomingContent;
+
+	return baseContent === null
+		? mergeContentTwoWay(incomingContent, currentContent)
+		: mergeContent(baseContent, incomingContent, currentContent);
 }

--- a/src/lib/utils/content-merge.ts
+++ b/src/lib/utils/content-merge.ts
@@ -78,19 +78,12 @@ export function mergeContent(base: string, local: string, remote: string): strin
 }
 
 /**
- * 2-way merge fallback when no base is available.
- * Without a common ancestor, edits and deletions cannot be distinguished from
- * concurrent changes. Preserve the current server document rather than
- * fabricating content by combining two complete snapshots.
- */
-export function mergeContentTwoWay(local: string, remote: string): string {
-	return remote;
-}
-
-/**
  * Merge an incoming content snapshot into the current server content.
- * Uses 3-way merge when a base is available; otherwise falls back to a
- * conservative 2-way merge instead of replacing the whole document.
+ *
+ * Uses a 3-way merge when a base (common ancestor) is available. Without a base —
+ * e.g. the base snapshot was pruned, or the version was bumped by a metadata-only
+ * change that created no snapshot — a 3-way merge is impossible, so keep the
+ * incoming edit rather than silently discarding the user's changes.
  */
 export function mergeContentUpdate(input: {
 	baseContent: string | null;
@@ -103,7 +96,10 @@ export function mergeContentUpdate(input: {
 	if (baseContent === incomingContent) return currentContent;
 	if (baseContent === currentContent) return incomingContent;
 
-	return baseContent === null
-		? mergeContentTwoWay(incomingContent, currentContent)
-		: mergeContent(baseContent, incomingContent, currentContent);
+	if (baseContent === null) {
+		console.warn('[content-merge] no base snapshot for concurrent edit; keeping incoming content');
+		return incomingContent;
+	}
+
+	return mergeContent(baseContent, incomingContent, currentContent);
 }


### PR DESCRIPTION
## Summary

Create version snapshots before mutating note content so later concurrent saves can find a base version. Reuse the content merge helper for direct updates and sync pushes, with tests covering fallback and queued-edit merge behavior.
