### PR TITLE
test(e2e): deflake dark-mode close→navigate race

### DIFF
--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -104,6 +104,11 @@ export async function createNote(page: Page, title: string, content?: string) {
 		await editor.pressSequentially(content);
 	}
 	await page.getByTestId('close-editor-btn').click();
+	// Wait for the editor to fully unmount, not just start closing. The close is
+	// animated and dismisses via an async history.back() (see NoteEditor); returning
+	// before it settles lets a following page.goto race that navigation and abort it
+	// (net::ERR_ABORTED). The outer overlay is removed only when the close completes.
+	await expect(page.getByTestId('note-editor-overlay')).toHaveCount(0);
 	await expect(noteCard(page, title)).toBeVisible();
 }
 


### PR DESCRIPTION
Fixes the intermittent `net::ERR_ABORTED at /settings/preferences` in `dark-mode.spec.ts` that blocked the 0.30.0 release.

**Root cause:** `createNote` returned as soon as the note card appeared, but since #71 the editor dismisses via an async `history.back()` + 400ms `onClose`. The next `page.goto` raced that in-flight client navigation and aborted it. It only reproduces under the slower coverage-instrumented CI build (local builds are too fast to hit the window).

**Fix:** `createNote` now waits for the editor overlay to fully unmount before returning, so the close navigation has settled.

Verified locally: dark-mode + notes-crud + search suites pass; the change is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)