### PR TITLE
Feat/note linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.58.0-noble
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
     steps:
       - uses: actions/checkout@v4
 

--- a/drizzle/0004_violet_nicolaos.sql
+++ b/drizzle/0004_violet_nicolaos.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `note_links` (
+	`source_note_id` text NOT NULL,
+	`target_note_id` text NOT NULL,
+	FOREIGN KEY (`source_note_id`) REFERENCES `notes`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`target_note_id`) REFERENCES `notes`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `note_links_source_idx` ON `note_links` (`source_note_id`);--> statement-breakpoint
+CREATE INDEX `note_links_target_idx` ON `note_links` (`target_note_id`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1233 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "785b6b61-24b1-4350-b0ca-18946b41e2ad",
+  "prevId": "518eb369-fbe9-41cf-ba2a-620dfc08d10c",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attachments_user_id_users_id_fk": {
+          "name": "attachments_user_id_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_note_id_notes_id_fk": {
+          "name": "attachments_note_id_notes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts": {
+      "name": "login_attempts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_attempts_ip_timestamp_idx": {
+          "name": "login_attempts_ip_timestamp_idx",
+          "columns": [
+            "ip",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_collaborators": {
+      "name": "note_collaborators",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_collaborators_unique": {
+          "name": "note_collaborators_unique",
+          "columns": [
+            "note_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "note_collaborators_user_id_idx": {
+          "name": "note_collaborators_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_collaborators_note_id_notes_id_fk": {
+          "name": "note_collaborators_note_id_notes_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_collaborators_user_id_users_id_fk": {
+          "name": "note_collaborators_user_id_users_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "note_collaborators_added_by_users_id_fk": {
+          "name": "note_collaborators_added_by_users_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_links": {
+      "name": "note_links",
+      "columns": {
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_links_source_idx": {
+          "name": "note_links_source_idx",
+          "columns": [
+            "source_note_id"
+          ],
+          "isUnique": false
+        },
+        "note_links_target_idx": {
+          "name": "note_links_target_idx",
+          "columns": [
+            "target_note_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_links_source_note_id_notes_id_fk": {
+          "name": "note_links_source_note_id_notes_id_fk",
+          "tableFrom": "note_links",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "source_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_links_target_note_id_notes_id_fk": {
+          "name": "note_links_target_note_id_notes_id_fk",
+          "tableFrom": "note_links",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "target_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_tags": {
+      "name": "note_tags",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_tags_note_id_idx": {
+          "name": "note_tags_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        },
+        "note_tags_tag_id_idx": {
+          "name": "note_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_tags_note_id_notes_id_fk": {
+          "name": "note_tags_note_id_notes_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_tags_tag_id_tags_id_fk": {
+          "name": "note_tags_tag_id_tags_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_user_state": {
+      "name": "note_user_state",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "note_user_state_unique": {
+          "name": "note_user_state_unique",
+          "columns": [
+            "note_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "note_user_state_note_id_notes_id_fk": {
+          "name": "note_user_state_note_id_notes_id_fk",
+          "tableFrom": "note_user_state",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_user_state_user_id_users_id_fk": {
+          "name": "note_user_state_user_id_users_id_fk",
+          "tableFrom": "note_user_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_versions": {
+      "name": "note_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "checklist_mode": {
+          "name": "checklist_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_versions_note_id_idx": {
+          "name": "note_versions_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        },
+        "note_versions_note_id_version_unique": {
+          "name": "note_versions_note_id_version_unique",
+          "columns": [
+            "note_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "note_versions_note_id_notes_id_fk": {
+          "name": "note_versions_note_id_notes_id_fk",
+          "tableFrom": "note_versions",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trashed": {
+          "name": "trashed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_mode": {
+          "name": "checklist_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "notes_user_id_idx": {
+          "name": "notes_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "notes_trashed_archived_idx": {
+          "name": "notes_trashed_archived_idx",
+          "columns": [
+            "trashed",
+            "archived"
+          ],
+          "isUnique": false
+        },
+        "notes_updated_at_idx": {
+          "name": "notes_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notes_user_id_users_id_fk": {
+          "name": "notes_user_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_notes": {
+      "name": "shared_notes",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shared_notes_token_unique": {
+          "name": "shared_notes_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "shared_notes_note_id_notes_id_fk": {
+          "name": "shared_notes_note_id_notes_id_fk",
+          "tableFrom": "shared_notes",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_log": {
+      "name": "sync_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_log_timestamp_idx": {
+          "name": "sync_log_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sync_log_user_id_users_id_fk": {
+          "name": "sync_log_user_id_users_id_fk",
+          "tableFrom": "sync_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sync_log_note_id_notes_id_fk": {
+          "name": "sync_log_note_id_notes_id_fk",
+          "tableFrom": "sync_log",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_user_unique": {
+          "name": "tags_name_user_unique",
+          "columns": [
+            "name",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_preferences_user_key_unique": {
+          "name": "user_preferences_user_key_unique",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'password'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1774037379518,
       "tag": "0003_uneven_tomorrow_man",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1785824271578,
+      "tag": "0004_violet_nicolaos",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/FormattingToolbar.svelte
+++ b/src/lib/components/FormattingToolbar.svelte
@@ -62,11 +62,15 @@
 			noteSearchResults = [];
 			return;
 		}
-		const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
-		if (requestId !== noteSearchRequestId) return;
-		if (!res.ok) return;
-		const results: { id: string; title: string }[] = await res.json();
-		noteSearchResults = results.filter((n) => n.id !== currentNoteId);
+		try {
+			const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+			if (requestId !== noteSearchRequestId) return;
+			if (!res.ok) return;
+			const results: { id: string; title: string }[] = await res.json();
+			noteSearchResults = results.filter((n) => n.id !== currentNoteId);
+		} catch {
+			// Search failed silently
+		}
 	}
 
 	let noteSearchRequestId = 0;
@@ -115,6 +119,7 @@
 	function closeDropdowns() {
 		openDropdown = null;
 		dropdownAnchorEl = null;
+		clearTimeout(noteSearchTimer);
 		noteSearchResults = [];
 	}
 

--- a/src/lib/components/FormattingToolbar.svelte
+++ b/src/lib/components/FormattingToolbar.svelte
@@ -33,9 +33,10 @@
 	interface Props {
 		tick?: number;
 		editor: Editor | undefined;
+		currentNoteId?: string | null;
 	}
 
-	let { editor, tick }: Props = $props();
+	let { editor, tick, currentNoteId = null }: Props = $props();
 
 	// A stale `editor` reference can still point at an instance mid-teardown (e.g. while
 	// NoteEditor swaps in a fresh Editor across a markdown-mode toggle); calling its
@@ -51,6 +52,36 @@
 	let linkUrl: string = $state('');
 	let linkInput: HTMLInputElement | undefined = $state();
 	let ignorePositionInvalidationUntil = 0;
+
+	let noteSearchResults: { id: string; title: string }[] = $state([]);
+	let noteSearchTimer: ReturnType<typeof setTimeout> | undefined;
+
+	async function searchNotesForLink(query: string) {
+		const requestId = ++noteSearchRequestId;
+		if (!query.trim()) {
+			noteSearchResults = [];
+			return;
+		}
+		const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+		if (requestId !== noteSearchRequestId) return;
+		if (!res.ok) return;
+		const results: { id: string; title: string }[] = await res.json();
+		noteSearchResults = results.filter((n) => n.id !== currentNoteId);
+	}
+
+	let noteSearchRequestId = 0;
+
+	function handleLinkInput() {
+		clearTimeout(noteSearchTimer);
+		noteSearchTimer = setTimeout(() => searchNotesForLink(linkUrl), 200);
+	}
+
+	function insertNoteLink(noteId: string) {
+		if (!editor) return;
+		editor.chain().focus().insertContent({ type: 'noteLink', attrs: { noteId } }).run();
+		noteSearchResults = [];
+		closeDropdowns();
+	}
 
 	const dropdownGap = 4;
 	const viewportMargin = 10;
@@ -84,6 +115,7 @@
 	function closeDropdowns() {
 		openDropdown = null;
 		dropdownAnchorEl = null;
+		noteSearchResults = [];
 	}
 
 	function closeDropdownsAfterPositionChange() {
@@ -437,6 +469,7 @@
 				<input
 					bind:this={linkInput}
 					bind:value={linkUrl}
+					oninput={handleLinkInput}
 					type="url"
 					placeholder="Paste a link..."
 					class="w-44 bg-transparent px-1.5 py-1 text-base md:text-sm text-[var(--text)] outline-none placeholder:text-[var(--text-muted)]"
@@ -475,6 +508,21 @@
 					<Trash2 size={16} />
 				</button>
 			</form>
+			{#if noteSearchResults.length > 0}
+				<div class="mt-1 max-h-40 overflow-y-auto border-t border-[var(--border-subtle)] pt-1">
+					{#each noteSearchResults as result (result.id)}
+						<button
+							type="button"
+							onmousedown={preventToolbarMouseFocus}
+							onclick={() => insertNoteLink(result.id)}
+							class="block w-full truncate rounded-sm px-1.5 py-1 text-left text-sm text-[var(--text)] hover:bg-[var(--hover-wash)]/10"
+							data-testid="format-link-note-result"
+						>
+							{result.title || 'Untitled'}
+						</button>
+					{/each}
+				</div>
+			{/if}
 		</div>
 	{:else if openDropdown === 'table'}
 		<div

--- a/src/lib/components/NoteEditor.svelte
+++ b/src/lib/components/NoteEditor.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { pushState } from '$app/navigation';
 	import { page } from '$app/state';
 	import ColorPicker from './ColorPicker.svelte';
@@ -19,7 +19,7 @@
 	import { getIsDarkMode } from '$lib/utils/theme.svelte.js';
 	import { getPreferences } from '$lib/stores/preferences.svelte.js';
 	import type { Editor } from '@tiptap/core';
-	import type { Note, NoteColor, Attachment, Collaborator } from '$lib/types/index.js';
+	import type { Note, NoteColor, Attachment, Collaborator, NoteBacklink } from '$lib/types/index.js';
 	import Palette from 'lucide-svelte/icons/palette';
 	import SquareCheck from 'lucide-svelte/icons/square-check';
 	import ImageIcon from 'lucide-svelte/icons/image';
@@ -165,8 +165,22 @@
 		return () => window.removeEventListener('beforeunload', handleBeforeUnload);
 	});
 
+	// Safety net for note-link/backlink navigation: NotesView.svelte remounts this
+	// component (rather than reusing the instance) whenever the user switches to a
+	// different note while the editor is open. That teardown skips the debounced
+	// autosave timer's cleanup (it only clears the timer, it doesn't flush) and
+	// beforeunload (which never fires for an in-SPA unmount), so a very recent edit
+	// could otherwise be silently dropped.
+	onDestroy(() => {
+		if (hasUnsavedChanges() && (title.trim() || content.trim())) {
+			performSave();
+		}
+	});
+
 	// svelte-ignore state_referenced_locally
 	let attachmentsList = $state<Attachment[]>(note?.attachments ?? []);
+	// svelte-ignore state_referenced_locally
+	let backlinksList = $state<NoteBacklink[]>(note?.backlinks ?? []);
 
 	let viewportHeight = $state('100dvh');
 	let viewportTop = $state('0px');
@@ -326,15 +340,45 @@
 		}
 	}
 
-	// Fetch attachments for existing notes if not pre-populated (e.g. loaded from IDB)
+	// Fetch attachments for existing notes if not pre-populated (e.g. loaded from IDB).
+	// Guarded against post-teardown writes: since NotesView.svelte now remounts this
+	// component on every note-switch (rather than reusing the instance), a fetch that
+	// resolves after teardown would otherwise write to $state on an already-destroyed
+	// instance racing the newly-mounted one.
 	$effect(() => {
 		if (noteId && !currentlyNew && (!note?.attachments || note.attachments.length === 0)) {
+			let destroyed = false;
 			fetch(`/api/notes/${noteId}/attachments`)
 				.then((res) => res.ok ? res.json() : [])
 				.then((data: Attachment[]) => {
+					if (destroyed) return;
 					if (data.length > 0) attachmentsList = data;
 				})
 				.catch(() => {});
+			return () => {
+				destroyed = true;
+			};
+		}
+	});
+
+	// Fetch backlinks for existing notes if not pre-populated (e.g. loaded from IDB) —
+	// note.backlinks is only ever attached server-side by getNote(), which nothing
+	// else in the client calls when opening a note (the bulk notes store and
+	// IndexedDB never carry it), so this mirrors the attachments effect above to
+	// fill it in on open. Same post-teardown guard as above.
+	$effect(() => {
+		if (noteId && !currentlyNew && (!note?.backlinks || note.backlinks.length === 0)) {
+			let destroyed = false;
+			fetch(`/api/notes/${noteId}`)
+				.then((res) => res.ok ? res.json() : null)
+				.then((data: Note | null) => {
+					if (destroyed) return;
+					if (data?.backlinks && data.backlinks.length > 0) backlinksList = data.backlinks;
+				})
+				.catch(() => {});
+			return () => {
+				destroyed = true;
+			};
 		}
 	});
 
@@ -619,11 +663,11 @@
 		{/if}
 
 		<!-- Backlinks -->
-		{#if note?.backlinks && note.backlinks.length > 0}
+		{#if backlinksList.length > 0}
 			<div class="border-t border-[var(--border-subtle)] px-4 py-2 shrink-0">
 				<p class="mb-1 text-xs font-medium text-[var(--text-muted)]">Referenced by</p>
 				<div class="flex flex-wrap gap-1.5">
-					{#each note.backlinks as backlink (backlink.id)}
+					{#each backlinksList as backlink (backlink.id)}
 						<button
 							type="button"
 							onclick={() => onOpenNote(backlink.id)}

--- a/src/lib/components/NoteEditor.svelte
+++ b/src/lib/components/NoteEditor.svelte
@@ -43,9 +43,10 @@
 		isNew?: boolean;
 		initialChecklistMode?: boolean;
 		onClose: () => void;
+		onOpenNote: (noteId: string) => void;
 	}
 
-	const { note, isNew = false, initialChecklistMode = false, onClose }: Props = $props();
+	const { note, isNew = false, initialChecklistMode = false, onClose, onOpenNote }: Props = $props();
 	const prefs = getPreferences();
 
 	// svelte-ignore state_referenced_locally
@@ -597,6 +598,7 @@
 					onUpdate={(md) => (content = md)}
 					onEditor={(e) => (tiptapEditor = e)}
 					onTransaction={() => editorTick++}
+					{onOpenNote}
 					placeholder="Add a crumb..."
 				/>
 			{/if}
@@ -616,10 +618,29 @@
 			</div>
 		{/if}
 
+		<!-- Backlinks -->
+		{#if note?.backlinks && note.backlinks.length > 0}
+			<div class="border-t border-[var(--border-subtle)] px-4 py-2 shrink-0">
+				<p class="mb-1 text-xs font-medium text-[var(--text-muted)]">Referenced by</p>
+				<div class="flex flex-wrap gap-1.5">
+					{#each note.backlinks as backlink (backlink.id)}
+						<button
+							type="button"
+							onclick={() => onOpenNote(backlink.id)}
+							class="rounded-sm border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-2 py-0.5 text-xs text-[var(--text)] hover:border-[var(--primary)]"
+							data-testid="backlink-chip"
+						>
+							{backlink.title || 'Untitled'}
+						</button>
+					{/each}
+				</div>
+			</div>
+		{/if}
+
 		<!-- Formatting toolbar -->
 		{#if !rawMarkdownMode && !checklistMode}
 			<div class="shrink-0 touch-pan-x" style={toolbarInteractive ? '' : 'pointer-events: none'}>
-				<FormattingToolbar editor={tiptapEditor} tick={editorTick} />
+				<FormattingToolbar editor={tiptapEditor} tick={editorTick} currentNoteId={noteId} />
 			</div>
 		{/if}
 

--- a/src/lib/components/NotesView.svelte
+++ b/src/lib/components/NotesView.svelte
@@ -9,6 +9,7 @@
 	import Plus from 'lucide-svelte/icons/plus';
 	import SquareCheck from 'lucide-svelte/icons/square-check';
 	import { tooltip } from '$lib/utils/tooltip.js';
+	import { getNote as getIdbNote } from '$lib/sync/idb.js';
 
 	interface Props {
 		filter: NoteFilter;
@@ -31,8 +32,18 @@
 	// Use SvelteKit's replaceState (not the raw history API) so the router keeps
 	// ownership of the entry — NoteEditor's close-on-back relies on popstate being
 	// handled by SvelteKit.
-	function openEditor(note: Note) {
-		editingNote = note;
+	async function openEditor(note: Note) {
+		try {
+			const res = await fetch(`/api/notes/${note.id}`);
+			if (res.ok) {
+				const full = await res.json();
+				editingNote = { ...note, backlinks: full.backlinks ?? [] };
+			} else {
+				editingNote = note;
+			}
+		} catch {
+			editingNote = note;
+		}
 		replaceState(`#${note.id}`, {});
 	}
 
@@ -41,6 +52,27 @@
 		showNewNote = false;
 		newNoteChecklist = false;
 		replaceState(location.pathname, {});
+	}
+
+	async function openNoteById(noteId: string) {
+		showNewNote = false;
+		newNoteChecklist = false;
+		editingNote = null;
+
+		try {
+			const res = await fetch(`/api/notes/${noteId}`);
+			if (res.ok) {
+				const full = await res.json();
+				editingNote = full;
+				replaceState(`#${noteId}`, {});
+			}
+		} catch {
+			const note = await getIdbNote(noteId);
+			if (note) {
+				editingNote = note;
+				replaceState(`#${noteId}`, {});
+			}
+		}
 	}
 
 	function handleReorder(noteIds: string[]) {
@@ -137,9 +169,9 @@
 {/if}
 
 {#if showNewNote}
-	<NoteEditor note={null} isNew={true} initialChecklistMode={newNoteChecklist} onClose={closeEditor} />
+	<NoteEditor note={null} isNew={true} initialChecklistMode={newNoteChecklist} onClose={closeEditor} onOpenNote={openNoteById} />
 {/if}
 
 {#if editingNote}
-	<NoteEditor note={editingNote} onClose={closeEditor} />
+	<NoteEditor note={editingNote} onClose={closeEditor} onOpenNote={openNoteById} />
 {/if}

--- a/src/lib/components/NotesView.svelte
+++ b/src/lib/components/NotesView.svelte
@@ -32,18 +32,8 @@
 	// Use SvelteKit's replaceState (not the raw history API) so the router keeps
 	// ownership of the entry — NoteEditor's close-on-back relies on popstate being
 	// handled by SvelteKit.
-	async function openEditor(note: Note) {
-		try {
-			const res = await fetch(`/api/notes/${note.id}`);
-			if (res.ok) {
-				const full = await res.json();
-				editingNote = { ...note, backlinks: full.backlinks ?? [] };
-			} else {
-				editingNote = note;
-			}
-		} catch {
-			editingNote = note;
-		}
+	function openEditor(note: Note) {
+		editingNote = note;
 		replaceState(`#${note.id}`, {});
 	}
 
@@ -54,25 +44,18 @@
 		replaceState(location.pathname, {});
 	}
 
-	async function openNoteById(noteId: string) {
-		showNewNote = false;
-		newNoteChecklist = false;
-		editingNote = null;
+	// Reads from the local IndexedDB cache rather than fetching over the network —
+	// this keeps note-link navigation instant and offline-safe (matching how the
+	// rest of the app opens notes), and backlinks are filled in progressively by
+	// NoteEditor's own fetch-if-not-pre-populated effect once the editor is open,
+	// the same pattern already used there for attachments.
+	let openNoteRequestId = 0;
 
-		try {
-			const res = await fetch(`/api/notes/${noteId}`);
-			if (res.ok) {
-				const full = await res.json();
-				editingNote = full;
-				replaceState(`#${noteId}`, {});
-			}
-		} catch {
-			const note = await getIdbNote(noteId);
-			if (note) {
-				editingNote = note;
-				replaceState(`#${noteId}`, {});
-			}
-		}
+	async function openNoteById(noteId: string) {
+		const requestId = ++openNoteRequestId;
+		const note = await getIdbNote(noteId);
+		if (requestId !== openNoteRequestId) return; // a newer navigation superseded this one
+		if (note) openEditor(note);
 	}
 
 	function handleReorder(noteIds: string[]) {
@@ -173,5 +156,13 @@
 {/if}
 
 {#if editingNote}
-	<NoteEditor note={editingNote} onClose={closeEditor} onOpenNote={openNoteById} />
+	<!-- Forces a full destroy+remount on note-switch (e.g. clicking a note-link
+	     while the editor is already open) instead of reusing the same instance
+	     with a new `note` prop — a persisting instance's own back-navigation
+	     effect misreads `openEditor`'s replaceState call as "browser back was
+	     pressed" and closes the editor, and its once-only local state never
+	     resyncs to the new note otherwise. -->
+	{#key editingNote.id}
+		<NoteEditor note={editingNote} onClose={closeEditor} onOpenNote={openNoteById} />
+	{/key}
 {/if}

--- a/src/lib/components/TiptapEditor.svelte
+++ b/src/lib/components/TiptapEditor.svelte
@@ -13,19 +13,24 @@
 	import TaskList from '@tiptap/extension-task-list';
 	import TaskItem from '@tiptap/extension-task-item';
 	import { Markdown } from 'tiptap-markdown';
+	import { NoteLink } from './tiptap/NoteLink.js';
+	import { getAllNotes } from '$lib/sync/idb.js';
 
 	interface Props {
 		content: string;
 		onUpdate: (markdown: string) => void;
 		onEditor?: (editor: Editor) => void;
 		onTransaction?: () => void;
+		onOpenNote?: (noteId: string) => void;
 		placeholder?: string;
 	}
 
-	let { content, onUpdate, onEditor, onTransaction, placeholder = 'Add a crumb...' }: Props = $props();
+	let { content, onUpdate, onEditor, onTransaction, onOpenNote, placeholder = 'Add a crumb...' }: Props = $props();
 
 	let element: HTMLDivElement | undefined = $state();
 	let editor: Editor | undefined = $state();
+
+	const titleIndexRef = { index: new Map<string, string>() };
 
 	function isTaskCheckboxTarget(target: EventTarget | null): boolean {
 		if (target instanceof Element) {
@@ -76,43 +81,53 @@
 	}
 
 	onMount(() => {
-		editor = new Editor({
-			element: element!,
-			extensions: [
-				StarterKit.configure({ link: false, underline: false }),
-				Link.configure({ openOnClick: false }),
-				Underline,
-				TextAlign.configure({ types: ['heading', 'paragraph'] }),
-				Placeholder.configure({ placeholder }),
-				Table.configure({ resizable: false }),
-				TableRow,
-				TableHeader,
-				TableCell,
+		let destroyed = false;
+		let editorInstance: Editor | undefined;
+
+		(async () => {
+			const allNotes = await getAllNotes();
+			if (destroyed) return;
+			titleIndexRef.index = new Map(allNotes.filter((n) => !n.trashed).map((n) => [n.id, n.title]));
+
+			editorInstance = new Editor({
+				element: element!,
+				extensions: [
+					StarterKit.configure({ link: false, underline: false }),
+					Link.configure({ openOnClick: false }),
+					Underline,
+					TextAlign.configure({ types: ['heading', 'paragraph'] }),
+					Placeholder.configure({ placeholder }),
+					Table.configure({ resizable: false }),
+					TableRow,
+					TableHeader,
+					TableCell,
 					TaskList,
-				TaskItem.configure({ nested: true }),
-				Markdown
-			],
-			content,
-			onUpdate: ({ editor: e }) => {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				onUpdate((e.storage as Record<string, any>).markdown.getMarkdown());
-			},
-			onTransaction: () => {
-				// Trigger Svelte reactivity for active state checks
-				editor = editor;
-				onTransaction?.();
+					TaskItem.configure({ nested: true }),
+					NoteLink.configure({ titleIndexRef, onOpenNote: onOpenNote ?? (() => {}) }),
+					Markdown
+				],
+				content,
+				onUpdate: ({ editor: e }) => {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					onUpdate((e.storage as Record<string, any>).markdown.getMarkdown());
+				},
+				onTransaction: () => {
+					editor = editorInstance;
+					onTransaction?.();
+				}
+			});
+			editor = editorInstance;
+
+			if (element && !destroyed) {
+				(element as any).__tiptapEditor = editorInstance;
 			}
-		});
 
-		// Expose editor on DOM element for e2e testing
-		if (element) {
-			(element as any).__tiptapEditor = editor;
-		}
-
-		onEditor?.(editor);
+			onEditor?.(editorInstance);
+		})();
 
 		return () => {
-			editor?.destroy();
+			destroyed = true;
+			editorInstance?.destroy();
 		};
 	});
 </script>

--- a/src/lib/components/TiptapEditor.svelte
+++ b/src/lib/components/TiptapEditor.svelte
@@ -108,12 +108,25 @@
 				],
 				content,
 				onUpdate: ({ editor: e }) => {
+					if (destroyed) return;
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 					onUpdate((e.storage as Record<string, any>).markdown.getMarkdown());
 				},
 				onTransaction: () => {
-					editor = editorInstance;
-					onTransaction?.();
+					// Removing this component's DOM node (e.g. a {#key}-driven remount
+					// in NotesView.svelte when switching to a different note) fires a
+					// native blur on the still-focused contenteditable, which
+					// ProseMirror's blur plugin turns into one last transaction —
+					// synchronously, from inside Svelte's own render/effect pass that's
+					// doing the removal. Mutating $state right there crashes with
+					// state_unsafe_mutation; the `destroyed` check alone isn't enough
+					// since this can fire before onMount's own cleanup runs. Defer to a
+					// microtask so the write lands after Svelte's current pass finishes.
+					queueMicrotask(() => {
+						if (destroyed) return;
+						editor = editorInstance;
+						onTransaction?.();
+					});
 				}
 			});
 			editor = editorInstance;

--- a/src/lib/components/tiptap/NoteLink.ts
+++ b/src/lib/components/tiptap/NoteLink.ts
@@ -1,0 +1,101 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { parseNoteLinkHref, serializeNoteLinkMarkdown } from './note-link-markdown.js';
+
+export interface NoteLinkOptions {
+	titleIndexRef: { index: Map<string, string> };
+	onOpenNote: (noteId: string) => void;
+}
+
+export const NoteLink = Node.create<NoteLinkOptions>({
+	name: 'noteLink',
+	group: 'inline',
+	inline: true,
+	atom: true,
+
+	addOptions() {
+		return {
+			titleIndexRef: { index: new Map<string, string>() },
+			onOpenNote: () => {}
+		};
+	},
+
+	addAttributes() {
+		return {
+			noteId: {
+				default: null,
+				parseHTML: (element) => element.getAttribute('data-note-id'),
+				renderHTML: (attributes) => ({ 'data-note-id': attributes.noteId })
+			}
+		};
+	},
+
+	parseHTML() {
+		return [
+			{
+				tag: 'a[href^="crumb-note://"]',
+				priority: 100,
+				getAttrs: (element) => {
+					const href = (element as HTMLElement).getAttribute('href') ?? '';
+					const noteId = parseNoteLinkHref(href);
+					return noteId ? { noteId } : false;
+				}
+			}
+		];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return ['a', mergeAttributes(HTMLAttributes, { href: `crumb-note://${HTMLAttributes['data-note-id']}` })];
+	},
+
+	addStorage() {
+		return {
+			markdown: {
+				serialize: (state: { write: (s: string) => void }, node: { attrs: { noteId: string } }) => {
+					state.write(serializeNoteLinkMarkdown(node.attrs.noteId, this.options.titleIndexRef.index));
+				}
+			}
+		};
+	},
+
+	addNodeView() {
+		return ({ node, editor, getPos }) => {
+			const noteId = node.attrs.noteId as string;
+			const title = this.options.titleIndexRef.index.get(noteId);
+
+			const dom = document.createElement('span');
+			dom.setAttribute('data-note-id', noteId);
+			dom.className =
+				'group relative inline-flex items-center gap-1 rounded-sm border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-1.5 py-0.5 text-sm';
+
+			const label = document.createElement('span');
+			if (title !== undefined) {
+				label.textContent = title;
+				label.className = 'cursor-pointer text-[var(--primary)] hover:text-[var(--primary-hover)]';
+				label.addEventListener('click', (event) => {
+					event.preventDefault();
+					this.options.onOpenNote(noteId);
+				});
+			} else {
+				label.textContent = 'Note not found';
+				label.className = 'text-[var(--text-muted)] opacity-60';
+			}
+			dom.appendChild(label);
+
+			const removeButton = document.createElement('button');
+			removeButton.type = 'button';
+			removeButton.textContent = '×';
+			removeButton.setAttribute('aria-label', 'Remove note link');
+			removeButton.className =
+				'max-md:opacity-100 md:opacity-0 transition-opacity md:group-hover:opacity-100 text-[var(--text-muted)] hover:text-[var(--destructive)]';
+			removeButton.addEventListener('click', (event) => {
+				event.preventDefault();
+				const pos = getPos();
+				if (pos === undefined) return;
+				editor.chain().focus().deleteRange({ from: pos, to: pos + node.nodeSize }).run();
+			});
+			dom.appendChild(removeButton);
+
+			return { dom };
+		};
+	}
+});

--- a/src/lib/components/tiptap/note-link-markdown.test.ts
+++ b/src/lib/components/tiptap/note-link-markdown.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { parseNoteLinkHref, serializeNoteLinkMarkdown } from './note-link-markdown.js';
+
+describe('parseNoteLinkHref', () => {
+	it('should extract the note ID from a crumb-note:// href', () => {
+		expect(parseNoteLinkHref('crumb-note://abc-123')).toBe('abc-123');
+	});
+
+	it('should return null for a non-crumb-note href', () => {
+		expect(parseNoteLinkHref('https://example.com')).toBeNull();
+	});
+
+	it('should return null for an empty string', () => {
+		expect(parseNoteLinkHref('')).toBeNull();
+	});
+});
+
+describe('serializeNoteLinkMarkdown', () => {
+	it('should produce a markdown link with the title from the index', () => {
+		const titleIndex = new Map([['abc-123', 'Grocery List']]);
+		expect(serializeNoteLinkMarkdown('abc-123', titleIndex)).toBe('[Grocery List](crumb-note://abc-123)');
+	});
+
+	it('should fall back to Untitled when the ID is not in the index', () => {
+		const titleIndex = new Map<string, string>();
+		expect(serializeNoteLinkMarkdown('missing-id', titleIndex)).toBe('[Untitled](crumb-note://missing-id)');
+	});
+
+	it('should escape markdown-special characters in the title', () => {
+		const titleIndex = new Map([['id-1', 'Buy [milk] today']]);
+		expect(serializeNoteLinkMarkdown('id-1', titleIndex)).toBe('[Buy \\[milk\\] today](crumb-note://id-1)');
+	});
+});

--- a/src/lib/components/tiptap/note-link-markdown.ts
+++ b/src/lib/components/tiptap/note-link-markdown.ts
@@ -1,0 +1,22 @@
+const NOTE_LINK_SCHEME = 'crumb-note://';
+
+/** Extracts the note ID from a crumb-note:// href, or null if it's not that scheme. */
+export function parseNoteLinkHref(href: string): string | null {
+	if (!href.startsWith(NOTE_LINK_SCHEME)) return null;
+	return href.slice(NOTE_LINK_SCHEME.length) || null;
+}
+
+/**
+ * Escapes markdown-special characters the same way a plain link's visible
+ * text is escaped, so a title containing `[`, `]`, `*`, etc. can't corrupt
+ * the surrounding markdown syntax.
+ */
+function escapeMarkdownText(text: string): string {
+	return text.replace(/[[\]\\*_`]/g, '\\$&');
+}
+
+/** Produces the `[title](crumb-note://id)` markdown representation of a note-link. */
+export function serializeNoteLinkMarkdown(noteId: string, titleIndex: Map<string, string>): string {
+	const title = titleIndex.get(noteId) ?? 'Untitled';
+	return `[${escapeMarkdownText(title)}](${NOTE_LINK_SCHEME}${noteId})`;
+}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -226,6 +226,13 @@ sqlite.exec(`
 		created_at INTEGER NOT NULL,
 		last_used_at INTEGER
 	);
+
+	CREATE TABLE IF NOT EXISTS note_links (
+		source_note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+		target_note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS note_links_source_idx ON note_links(source_note_id);
+	CREATE INDEX IF NOT EXISTS note_links_target_idx ON note_links(target_note_id);
 `);
 
 // Replace old tags unique index with compound index including user_id

--- a/src/lib/server/db/note-links-schema.test.ts
+++ b/src/lib/server/db/note-links-schema.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { createTestDb } from './test-helpers.js';
+import { notes, noteLinks, users } from './schema.js';
+
+describe('noteLinks schema', () => {
+	it('should store a source/target link row', () => {
+		const { db } = createTestDb();
+		db.insert(users)
+			.values({ email: 'a@test.com', displayName: 'A', role: 'user', authProvider: 'password', createdAt: new Date() })
+			.run();
+
+		db.insert(notes)
+			.values([
+				{ id: 'source-note', userId: 1, title: 'Source', content: '', createdAt: new Date(), updatedAt: new Date() },
+				{ id: 'target-note', userId: 1, title: 'Target', content: '', createdAt: new Date(), updatedAt: new Date() }
+			])
+			.run();
+
+		db.insert(noteLinks).values({ sourceNoteId: 'source-note', targetNoteId: 'target-note' }).run();
+
+		const rows = db.select().from(noteLinks).all();
+		expect(rows).toEqual([{ sourceNoteId: 'source-note', targetNoteId: 'target-note' }]);
+	});
+
+	it('should cascade-delete link rows when the source note is deleted', () => {
+		const { db, sqlite } = createTestDb();
+		sqlite.pragma('foreign_keys = ON');
+		db.insert(users)
+			.values({ email: 'a@test.com', displayName: 'A', role: 'user', authProvider: 'password', createdAt: new Date() })
+			.run();
+		db.insert(notes)
+			.values([
+				{ id: 'source-note', userId: 1, title: 'Source', content: '', createdAt: new Date(), updatedAt: new Date() },
+				{ id: 'target-note', userId: 1, title: 'Target', content: '', createdAt: new Date(), updatedAt: new Date() }
+			])
+			.run();
+		db.insert(noteLinks).values({ sourceNoteId: 'source-note', targetNoteId: 'target-note' }).run();
+
+		db.delete(notes).where(eq(notes.id, 'source-note')).run();
+
+		expect(db.select().from(noteLinks).all()).toEqual([]);
+	});
+});

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -80,6 +80,22 @@ export const noteTags = sqliteTable(
 	]
 );
 
+export const noteLinks = sqliteTable(
+	'note_links',
+	{
+		sourceNoteId: text('source_note_id')
+			.references(() => notes.id, { onDelete: 'cascade' })
+			.notNull(),
+		targetNoteId: text('target_note_id')
+			.references(() => notes.id, { onDelete: 'cascade' })
+			.notNull()
+	},
+	(table) => [
+		index('note_links_source_idx').on(table.sourceNoteId),
+		index('note_links_target_idx').on(table.targetNoteId)
+	]
+);
+
 export const attachments = sqliteTable('attachments', {
 	id: text('id').primaryKey(),
 	userId: integer('user_id')

--- a/src/lib/server/db/test-helpers.ts
+++ b/src/lib/server/db/test-helpers.ts
@@ -68,6 +68,13 @@ export function createTestDb(options?: { seedUser?: boolean }) {
 		CREATE INDEX note_tags_note_id_idx ON note_tags(note_id);
 		CREATE INDEX note_tags_tag_id_idx ON note_tags(tag_id);
 
+		CREATE TABLE note_links (
+			source_note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+			target_note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE
+		);
+		CREATE INDEX note_links_source_idx ON note_links(source_note_id);
+		CREATE INDEX note_links_target_idx ON note_links(target_note_id);
+
 		CREATE TABLE note_collaborators (
 			note_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
 			user_id INTEGER NOT NULL REFERENCES users(id),

--- a/src/lib/server/note-links.test.ts
+++ b/src/lib/server/note-links.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestDb } from './db/test-helpers.js';
+import { notes, noteLinks, noteCollaborators, users } from './db/schema.js';
+import type { Db } from './db/index.js';
+import { syncNoteLinks, fetchBacklinksForNote } from './note-links.js';
+
+let db: Db;
+const OWNER_ID = 1;
+const OTHER_USER_ID = 2;
+
+function seedUser(id: number, email: string) {
+	db.insert(users)
+		.values({ id, email, displayName: email, role: 'user', authProvider: 'password', createdAt: new Date() })
+		.run();
+}
+
+function seedNote(id: string, userId: number, title = '') {
+	db.insert(notes)
+		.values({ id, userId, title, content: '', createdAt: new Date(), updatedAt: new Date() })
+		.run();
+}
+
+beforeEach(() => {
+	const testDb = createTestDb();
+	db = testDb.db;
+	seedUser(OWNER_ID, 'owner@test.com');
+	seedUser(OTHER_USER_ID, 'other@test.com');
+});
+
+describe('syncNoteLinks', () => {
+	it('should create link rows for each target', () => {
+		seedNote('source', OWNER_ID);
+		seedNote('target-1', OWNER_ID);
+		seedNote('target-2', OWNER_ID);
+
+		syncNoteLinks(db, 'source', ['target-1', 'target-2']);
+
+		const rows = db.select().from(noteLinks).all();
+		expect(rows).toHaveLength(2);
+	});
+
+	it('should remove old links and add new ones on re-sync', () => {
+		seedNote('source', OWNER_ID);
+		seedNote('target-1', OWNER_ID);
+		seedNote('target-2', OWNER_ID);
+
+		syncNoteLinks(db, 'source', ['target-1']);
+		syncNoteLinks(db, 'source', ['target-2']);
+
+		const rows = db.select().from(noteLinks).all();
+		expect(rows).toEqual([{ sourceNoteId: 'source', targetNoteId: 'target-2' }]);
+	});
+
+	it('should handle an empty target list (removes all links)', () => {
+		seedNote('source', OWNER_ID);
+		seedNote('target-1', OWNER_ID);
+
+		syncNoteLinks(db, 'source', ['target-1']);
+		syncNoteLinks(db, 'source', []);
+
+		expect(db.select().from(noteLinks).all()).toEqual([]);
+	});
+});
+
+describe('fetchBacklinksForNote', () => {
+	it('should return notes that link to the given note', () => {
+		seedNote('source', OWNER_ID, 'Source Note');
+		seedNote('target', OWNER_ID, 'Target Note');
+		syncNoteLinks(db, 'source', ['target']);
+
+		const backlinks = fetchBacklinksForNote(db, 'target', OWNER_ID);
+		expect(backlinks).toEqual([{ id: 'source', title: 'Source Note' }]);
+	});
+
+	it('should return an empty array when nothing links to the note', () => {
+		seedNote('target', OWNER_ID, 'Target Note');
+		expect(fetchBacklinksForNote(db, 'target', OWNER_ID)).toEqual([]);
+	});
+
+	it('should exclude a backlink from a source note the requesting user cannot access', () => {
+		seedNote('source', OTHER_USER_ID, 'Other Users Note');
+		seedNote('target', OWNER_ID, 'Target Note');
+		syncNoteLinks(db, 'source', ['target']);
+
+		expect(fetchBacklinksForNote(db, 'target', OWNER_ID)).toEqual([]);
+	});
+
+	it('should include a backlink from a source note shared with the requesting user', () => {
+		seedNote('source', OTHER_USER_ID, 'Shared Source');
+		seedNote('target', OWNER_ID, 'Target Note');
+		syncNoteLinks(db, 'source', ['target']);
+		db.insert(noteCollaborators)
+			.values({ noteId: 'source', userId: OWNER_ID, addedBy: OTHER_USER_ID, addedAt: new Date() })
+			.run();
+
+		expect(fetchBacklinksForNote(db, 'target', OWNER_ID)).toEqual([{ id: 'source', title: 'Shared Source' }]);
+	});
+});

--- a/src/lib/server/note-links.ts
+++ b/src/lib/server/note-links.ts
@@ -1,0 +1,48 @@
+import type { Db } from './db/index.js';
+import { noteLinks, notes } from './db/schema.js';
+import { eq, inArray } from 'drizzle-orm';
+import { canAccessNote } from './api-utils.js';
+
+/**
+ * Sync link rows for a note: removes old associations, inserts the current set.
+ * Mirrors syncNoteTags — called right after a note's content is saved.
+ */
+export function syncNoteLinks(db: Db, noteId: string, targetIds: string[]): void {
+	db.delete(noteLinks).where(eq(noteLinks.sourceNoteId, noteId)).run();
+
+	for (const targetId of targetIds) {
+		db.insert(noteLinks).values({ sourceNoteId: noteId, targetNoteId: targetId }).run();
+	}
+}
+
+/**
+ * Find notes that link to the given note, scoped to what the requesting user
+ * can access — this both respects normal sharing boundaries and, as a side
+ * effect, prevents an unrelated note from appearing in someone's backlinks
+ * just because it happens to reference a note ID it was never shared to see.
+ */
+export function fetchBacklinksForNote(
+	db: Db,
+	noteId: string,
+	userId: number
+): { id: string; title: string }[] {
+	const linkRows = db
+		.select({ sourceNoteId: noteLinks.sourceNoteId })
+		.from(noteLinks)
+		.where(eq(noteLinks.targetNoteId, noteId))
+		.all();
+
+	if (linkRows.length === 0) return [];
+
+	const sourceIds = linkRows.map((r) => r.sourceNoteId);
+	const accessibleIds = sourceIds.filter((id) => canAccessNote(db, id, userId).canAccess);
+	if (accessibleIds.length === 0) return [];
+
+	const sourceNotes = db
+		.select({ id: notes.id, title: notes.title })
+		.from(notes)
+		.where(inArray(notes.id, accessibleIds))
+		.all();
+
+	return sourceNotes;
+}

--- a/src/lib/server/notes-service.test.ts
+++ b/src/lib/server/notes-service.test.ts
@@ -374,3 +374,45 @@ describe('reorderNotes', () => {
 		expect(collabView!.sortOrder).toBe(5);
 	});
 });
+
+describe('note links', () => {
+	it('should sync note-links when a note is created with a reference', () => {
+		const target = createNote(db, OWNER_ID, { title: 'Target' });
+		const source = createNote(db, OWNER_ID, {
+			title: 'Source',
+			content: `See [Target](crumb-note://${target.id})`
+		});
+
+		const reopened = getNote(db, OWNER_ID, target.id);
+		expect(reopened?.backlinks).toEqual([{ id: source.id, title: 'Source' }]);
+	});
+
+	it('should sync note-links when a note is updated with a reference', () => {
+		const target = createNote(db, OWNER_ID, { title: 'Target' });
+		const source = createNote(db, OWNER_ID, { title: 'Source', content: '' });
+
+		updateNote(db, OWNER_ID, source.id, { content: `See [Target](crumb-note://${target.id})` });
+
+		const reopened = getNote(db, OWNER_ID, target.id);
+		expect(reopened?.backlinks).toEqual([{ id: source.id, title: 'Source' }]);
+	});
+
+	it('should remove a backlink when the referencing note is edited to drop the reference', () => {
+		const target = createNote(db, OWNER_ID, { title: 'Target' });
+		const source = createNote(db, OWNER_ID, {
+			title: 'Source',
+			content: `See [Target](crumb-note://${target.id})`
+		});
+
+		updateNote(db, OWNER_ID, source.id, { content: 'No longer references anything' });
+
+		const reopened = getNote(db, OWNER_ID, target.id);
+		expect(reopened?.backlinks).toEqual([]);
+	});
+
+	it('should return an empty backlinks array for a note nothing links to', () => {
+		const note = createNote(db, OWNER_ID, { title: 'Lonely note' });
+		const reopened = getNote(db, OWNER_ID, note.id);
+		expect(reopened?.backlinks).toEqual([]);
+	});
+});

--- a/src/lib/server/notes-service.ts
+++ b/src/lib/server/notes-service.ts
@@ -3,7 +3,9 @@ import { notes, noteTags, tags, noteCollaborators, noteUserState } from './db/sc
 import { eq, and, like, or, inArray, sql } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { extractTags } from '$lib/utils/tags.js';
+import { extractNoteLinks } from '$lib/utils/note-links.js';
 import { fetchTagsForNotes, syncNoteTags } from './tags.js';
+import { syncNoteLinks, fetchBacklinksForNote } from './note-links.js';
 import { fetchAttachmentsForNotes } from './attachments.js';
 import { fetchCollaboratorsForNotes } from './collaborators.js';
 import { fetchSharesForNotes } from './shares-service.js';
@@ -155,7 +157,10 @@ export function getNote(db: Db, userId: number, id: string) {
 	}
 
 	const result = hydrateNotes(db, [effectiveNote], userId);
-	return result[0] ?? null;
+	const hydrated = result[0];
+	if (!hydrated) return null;
+
+	return { ...hydrated, backlinks: fetchBacklinksForNote(db, id, userId) };
 }
 
 export interface CreateNoteInput {
@@ -196,6 +201,9 @@ export function createNote(db: Db, userId: number, input: CreateNoteInput) {
 		tx.insert(notes).values(newNote).run();
 	});
 	syncNoteTags(db, id, extractedTags, userId);
+
+	const extractedLinks = extractNoteLinks(content);
+	syncNoteLinks(db, id, extractedLinks);
 
 	return { ...newNote, tags: extractedTags };
 }
@@ -326,6 +334,8 @@ export function updateNote(db: Db, userId: number, id: string, input: UpdateNote
 			const content = `${updated.title} ${updated.content}`;
 			const extractedTags = extractTags(content);
 			syncNoteTags(db, id, extractedTags, existing.userId);
+			const extractedLinks = extractNoteLinks(content);
+			syncNoteLinks(db, id, extractedLinks);
 		}
 	}
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,6 +18,12 @@ export interface Note {
 	isOwner?: boolean;
 	isShared?: boolean;
 	shareToken?: string;
+	backlinks?: NoteBacklink[];
+}
+
+export interface NoteBacklink {
+	id: string;
+	title: string;
 }
 
 export interface Collaborator {

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -85,3 +85,16 @@ describe('stripMarkdown', () => {
 		expect(stripMarkdown('')).toBe('');
 	});
 });
+
+describe('renderMarkdown note-link handling', () => {
+	it('should render a crumb-note:// link as plain text, not a clickable anchor', () => {
+		const html = renderMarkdown('See [Grocery List](crumb-note://abc-123) for details');
+		expect(html).not.toContain('<a');
+		expect(html).toContain('Grocery List');
+	});
+
+	it('should still render a normal external link as a real anchor', () => {
+		const html = renderMarkdown('See [Example](https://example.com) for details');
+		expect(html).toContain('<a href="https://example.com"');
+	});
+});

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -39,6 +39,25 @@ md.core.ruler.after('inline', 'task-lists', (state) => {
 	}
 });
 
+md.core.ruler.after('task-lists', 'note-links', (state) => {
+	for (const token of state.tokens) {
+		if (token.type !== 'inline' || !token.children) continue;
+
+		const children = token.children;
+		for (let i = 0; i < children.length; i++) {
+			if (children[i].type !== 'link_open') continue;
+			const href = children[i].attrGet('href') ?? '';
+			if (!href.startsWith('crumb-note://')) continue;
+
+			let closeIndex = i + 1;
+			while (closeIndex < children.length && children[closeIndex].type !== 'link_close') closeIndex++;
+			children.splice(closeIndex, 1);
+			children.splice(i, 1);
+			i -= 1;
+		}
+	}
+});
+
 export function renderMarkdown(content: string): string {
 	return md.render(content);
 }

--- a/src/lib/utils/note-links.test.ts
+++ b/src/lib/utils/note-links.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { extractNoteLinks } from './note-links.js';
+
+describe('extractNoteLinks', () => {
+	it('should extract a single note-link reference', () => {
+		expect(extractNoteLinks('See [Grocery List](crumb-note://abc-123)')).toEqual(['abc-123']);
+	});
+
+	it('should extract multiple distinct references', () => {
+		const content = '[A](crumb-note://id-1) and [B](crumb-note://id-2)';
+		expect(extractNoteLinks(content)).toEqual(['id-1', 'id-2']);
+	});
+
+	it('should deduplicate repeated references', () => {
+		const content = '[A](crumb-note://id-1) again: [A again](crumb-note://id-1)';
+		expect(extractNoteLinks(content)).toEqual(['id-1']);
+	});
+
+	it('should return an empty array for content with no note-links', () => {
+		expect(extractNoteLinks('Just [a normal link](https://example.com)')).toEqual([]);
+	});
+
+	it('should return an empty array for empty content', () => {
+		expect(extractNoteLinks('')).toEqual([]);
+	});
+
+	it('should not match crumb-note:// occurring inside a code block', () => {
+		const content = '```\n[A](crumb-note://id-1)\n```';
+		expect(extractNoteLinks(content)).toEqual([]);
+	});
+
+	it('should not match crumb-note:// occurring inside inline code', () => {
+		expect(extractNoteLinks('Use `crumb-note://id-1` as an example')).toEqual([]);
+	});
+});

--- a/src/lib/utils/note-links.ts
+++ b/src/lib/utils/note-links.ts
@@ -1,0 +1,17 @@
+/**
+ * Extract crumb-note://<id> references from markdown content.
+ * Mirrors extractTags' code-block/inline-code exclusion so a reference
+ * mentioned as an example inside a code sample isn't treated as a real link.
+ */
+export function extractNoteLinks(content: string): string[] {
+	if (!content) return [];
+
+	const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, '');
+	const withoutInlineCode = withoutCodeBlocks.replace(/`[^`]*`/g, '');
+
+	const matches = withoutInlineCode.match(/crumb-note:\/\/([\w-]+)/g);
+	if (!matches) return [];
+
+	const ids = matches.map((m) => m.replace('crumb-note://', ''));
+	return [...new Set(ids)];
+}

--- a/tests/e2e/formatting.spec.ts
+++ b/tests/e2e/formatting.spec.ts
@@ -13,6 +13,14 @@ async function runTiptapCommand(page: Page, commandFn: string) {
 	);
 }
 
+async function waitForTiptapEditor(page: Page) {
+	await page.getByTestId('tiptap-editor').waitFor({ state: 'visible' });
+	await page.waitForFunction(() => {
+		const el = document.querySelector('[data-testid="tiptap-editor"]');
+		return el && (el as any).__tiptapEditor != null;
+	});
+}
+
 /**
  * Read the `checked` attribute of the first task item from the live ProseMirror
  * document. This reflects the editor's document state, not just the native
@@ -57,6 +65,7 @@ test.describe('Rich text formatting', () => {
 		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
 
 		// When the user selects "world" and applies bold formatting
+		await waitForTiptapEditor(page);
 		await runTiptapCommand(page, 'editor.chain().focus().setTextSelection({from:7,to:12}).toggleBold().run()');
 
 		// Then the selected text appears bold in the editor
@@ -99,6 +108,7 @@ test.describe('Rich text formatting', () => {
 		// Given the user is editing a note with selected text
 		await page.getByTestId('new-note-btn').click();
 		await typeViaMarkdown(page, 'visit example');
+		await waitForTiptapEditor(page);
 		await runTiptapCommand(page, 'editor.chain().focus().setTextSelection({from:7,to:14}).run()');
 
 		// When the user opens the link popover and enters a URL

--- a/tests/e2e/helpers/fixtures.ts
+++ b/tests/e2e/helpers/fixtures.ts
@@ -13,9 +13,18 @@ const COLLAB_EMAIL = 'collab@test.com';
 const COLLAB_PASSWORD = collabPassword;
 const COLLAB_NAME = 'Collaborator User';
 
-/** Find a specific note card by its title text */
+/**
+ * Find a specific note card by its exact title text. Matches only the
+ * card's <h3> title, not its full text content — with note-linking, a
+ * card's content preview can render another note's title as plain text
+ * (e.g. a stripped note-link), so a substring match against the whole
+ * card can ambiguously resolve to more than one card.
+ */
 export function noteCard(page: Page, title: string): Locator {
-	return page.locator('[data-testid="note-card"]', { hasText: title });
+	const escaped = title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return page.locator('[data-testid="note-card"]').filter({
+		has: page.locator('h3', { hasText: new RegExp(`^${escaped}$`) })
+	});
 }
 
 /**

--- a/tests/e2e/note-linking.spec.ts
+++ b/tests/e2e/note-linking.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, createNote, noteCard } from './helpers/fixtures.js';
+
+test.describe('Note Linking', () => {
+	test('Scenario: Linking to a note renders a live chip and clicking it opens that note', async ({ authenticatedPage: page }) => {
+		await createNote(page, 'Target Note', 'target content');
+		await createNote(page, 'Source Note', 'source content');
+
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Linker Note');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Target');
+		await page.getByTestId('format-link-note-result').filter({ hasText: 'Target Note' }).click();
+
+		await expect(page.getByTestId('tiptap-editor').locator('[data-note-id]')).toBeVisible();
+		await page.getByTestId('tiptap-editor').locator('[data-note-id]').click();
+
+		await expect(page.getByTestId('note-title-input').first()).toHaveValue('Target Note');
+	});
+
+	test('Scenario: Renaming a linked note updates the displayed link text', async ({ authenticatedPage: page }) => {
+		await createNote(page, 'Original Title', '');
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Linker Note');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Original');
+		await page.getByTestId('format-link-note-result').filter({ hasText: 'Original Title' }).click();
+		await page.getByTestId('close-editor-btn').click();
+
+		await noteCard(page, 'Original Title').click();
+		await page.getByTestId('note-title-input').fill('Renamed Title');
+		await page.getByTestId('close-editor-btn').click();
+
+		await noteCard(page, 'Linker Note').click();
+		await expect(editor.getByText('Renamed Title')).toBeVisible();
+		await expect(editor.getByText('Original Title')).not.toBeVisible();
+	});
+
+	test('Scenario: A link to a trashed note renders inert and does not navigate', async ({ authenticatedPage: page }) => {
+		await createNote(page, 'Doomed Note', '');
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Linker Note');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Doomed');
+		await page.getByTestId('format-link-note-result').filter({ hasText: 'Doomed Note' }).click();
+		await page.getByTestId('close-editor-btn').click();
+
+		await noteCard(page, 'Doomed Note').click();
+		await page.getByTestId('overflow-menu-btn').click();
+		await page.getByTestId('trash-note-btn').click();
+		await expect(page.getByTestId('note-editor-overlay')).toHaveCount(0);
+
+		await noteCard(page, 'Linker Note').click();
+		await expect(editor.getByText('Note not found')).toBeVisible();
+		await editor.getByText('Note not found').click();
+		await expect(page.getByTestId('note-title-input').first()).toHaveValue('Linker Note');
+	});
+
+	test('Scenario: The linked-to note shows a Referenced by backlink', async ({ authenticatedPage: page }) => {
+		await createNote(page, 'Popular Note', '');
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Referencing Note');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Popular');
+		await page.getByTestId('format-link-note-result').filter({ hasText: 'Popular Note' }).click();
+		await page.getByTestId('close-editor-btn').click();
+
+		await noteCard(page, 'Popular Note').click();
+
+		await expect(page.getByTestId('backlink-chip').filter({ hasText: 'Referencing Note' })).toBeVisible();
+	});
+
+	test('Scenario: The note-picker excludes the currently-open note from its own search results', async ({ authenticatedPage: page }) => {
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Self Reference Test');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Self Reference');
+
+		await expect(page.getByTestId('format-link-note-result').filter({ hasText: 'Self Reference Test' })).toHaveCount(0);
+	});
+
+	test('Scenario: Hovering a note-link chip reveals a remove button that deletes it without navigating', async ({ authenticatedPage: page }) => {
+		await createNote(page, 'Removable Target', '');
+		await page.getByTestId('new-note-btn').click();
+		await page.getByTestId('note-title-input').fill('Has A Link');
+		const editor = page.getByTestId('tiptap-editor').locator('.tiptap');
+		await editor.click();
+		await page.getByTestId('format-link').click();
+		await page.getByTestId('format-link-input').fill('Removable');
+		await page.getByTestId('format-link-note-result').filter({ hasText: 'Removable Target' }).click();
+
+		const chip = page.getByTestId('tiptap-editor').locator('[data-note-id]');
+		await expect(chip).toBeVisible();
+		await chip.hover();
+		await page.getByRole('button', { name: 'Remove note link' }).click();
+
+		await expect(chip).toHaveCount(0);
+		await expect(page.getByTestId('note-title-input').first()).toHaveValue('Has A Link');
+	});
+});


### PR DESCRIPTION
## Summary

### What
Notes can now reference each other via the existing link toolbar. A note-link renders as a live chip whose label always tracks the target's current title, and the target note shows a "Referenced by" backlinks section.

### Why
Users want to build connected notes (a master crumb with linked sub-crumbs) for a proper note-taking experience. Previously the link button only supported external URLs - there was no way to link one crumb to another.

### How ( architecture )
- New note_links join table (source → target, cascade deletes) mirrors the existing noteTags pattern
- Custom TipTap atomic inline node (NoteLink) renders a live chip with the target's title from a synchronous IndexedDB-backed title index
- Round-trips through markdown as [title](crumb-note://<id>)
- Note-search results appear in the existing link toolbar dropdown alongside the URL input (both affordances work side by side)
- Backlinks computed only in getNote() (single-note load), not hydrateNotes() (list views)

## Test Plan

- [x] Unit tests added/updated
- [x] E2E tests added/updated (if user-facing)
- [x] `make check` passes
- [x] `make test` passes

## Related Issues

Closes #74 

## Video

https://github.com/user-attachments/assets/b77f6b67-f98a-4c8e-ae2f-80807dd29826



