### PR TITLE
fix(auth): require a verified email before an OAuth identity claims an account

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,6 +1,6 @@
 import { db, sqlite } from './db/index.js';
 import { users, sessions } from './db/schema.js';
-import { eq, lt, and } from 'drizzle-orm';
+import { eq, lt, and, isNull } from 'drizzle-orm';
 import * as argon2 from 'argon2';
 import { randomBytes } from 'crypto';
 import type { User } from '$lib/types/index.js';
@@ -318,9 +318,23 @@ export function findOrLinkOAuthUser(
 		.get();
 	if (byProvider) return toUser(byProvider);
 
-	// Try matching by email (invite-only: user must already exist)
-	const byEmail = db.select().from(users).where(eq(users.email, email)).get();
-	if (!byEmail) return null; // No matching user — not invited
+	// Try matching by email (invite-only: user must already exist).
+	//
+	// Restricted to accounts with no provider identity on file. Without that, an
+	// address asserted by the IdP could be linked onto an account that already
+	// belongs to a different provider identity — overwriting provider_id below and
+	// handing over the account. Nothing in the app can clear provider_id, so such a
+	// takeover would outlast a session revocation and be undoable only by deleting
+	// the user, which cascades away their notes.
+	//
+	// An invited account that has never signed in still has provider_id NULL, so the
+	// documented invite flow is unaffected.
+	const byEmail = db
+		.select()
+		.from(users)
+		.where(and(eq(users.email, email), isNull(users.providerId)))
+		.get();
+	if (!byEmail) return null; // Not invited, or already linked to another identity
 
 	// Link this OAuth provider to the existing user
 	db.update(users)

--- a/src/lib/server/oauth/github.ts
+++ b/src/lib/server/oauth/github.ts
@@ -1,5 +1,6 @@
 import * as arctic from 'arctic';
 import { getGithubClient } from './providers.js';
+import { verifiedGithubEmail } from './verified-email.js';
 
 export function createGithubAuthUrl(): { url: URL; state: string } | null {
 	const github = getGithubClient();
@@ -26,21 +27,23 @@ export async function validateGithubCallback(
 		headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
 	});
 	if (!userRes.ok) return null;
-	const user = (await userRes.json()) as { id: number; login: string; name?: string; email?: string };
+	const user = (await userRes.json()) as { id: number; login: string; name?: string };
 
-	// GitHub may not return email in profile — fetch from emails endpoint
-	let email = user.email;
-	if (!email) {
-		const emailsRes = await fetch('https://api.github.com/user/emails', {
-			headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
-		});
-		if (emailsRes.ok) {
-			const emails = (await emailsRes.json()) as { email: string; primary: boolean; verified: boolean }[];
-			const primary = emails.find((e) => e.primary && e.verified);
-			email = primary?.email || emails.find((e) => e.verified)?.email || undefined;
-		}
-	}
+	// Always resolve the address from /user/emails, never from the profile. The
+	// profile's `email` carries no verification flag, so it cannot support the trust
+	// decision this address is used for. The `user:email` scope is requested above,
+	// so this endpoint is available.
+	const emailsRes = await fetch('https://api.github.com/user/emails', {
+		headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' }
+	});
+	if (!emailsRes.ok) return null;
 
+	const emails = (await emailsRes.json()) as {
+		email: string;
+		primary: boolean;
+		verified: boolean;
+	}[];
+	const email = verifiedGithubEmail(emails);
 	if (!email) return null;
 
 	return {

--- a/src/lib/server/oauth/google.ts
+++ b/src/lib/server/oauth/google.ts
@@ -1,5 +1,6 @@
 import * as arctic from 'arctic';
 import { getGoogleClient } from './providers.js';
+import { verifiedEmailFromClaims } from './verified-email.js';
 
 export function createGoogleAuthUrl(): { url: URL; state: string; codeVerifier: string } | null {
 	const google = getGoogleClient();
@@ -25,14 +26,17 @@ export async function validateGoogleCallback(
 	const claims = arctic.decodeIdToken(idToken) as {
 		sub: string;
 		email?: string;
+		email_verified?: boolean;
 		name?: string;
 	};
 
-	if (!claims.email) return null;
+	// Only a verified address may identify an account — see verified-email.ts.
+	const email = verifiedEmailFromClaims(claims);
+	if (!email) return null;
 
 	return {
-		email: claims.email,
-		name: claims.name || claims.email.split('@')[0],
+		email,
+		name: claims.name || email.split('@')[0],
 		providerId: claims.sub
 	};
 }

--- a/src/lib/server/oauth/oidc.ts
+++ b/src/lib/server/oauth/oidc.ts
@@ -1,4 +1,5 @@
 import * as arctic from 'arctic';
+import { verifiedEmailFromClaims } from './verified-email.js';
 
 let oidcClient: arctic.OAuth2Client | null = null;
 let oidcConfig: {
@@ -85,12 +86,14 @@ export async function validateOidcCallback(
 		const claims = arctic.decodeIdToken(idToken) as {
 			sub: string;
 			email?: string;
+			email_verified?: boolean;
 			name?: string;
 		};
-		if (claims.email) {
+		const claimEmail = verifiedEmailFromClaims(claims);
+		if (claimEmail) {
 			return {
-				email: claims.email,
-				name: claims.name || claims.email.split('@')[0],
+				email: claimEmail,
+				name: claims.name || claimEmail.split('@')[0],
 				providerId: claims.sub
 			};
 		}
@@ -106,14 +109,17 @@ export async function validateOidcCallback(
 	const userInfo = (await userRes.json()) as {
 		sub: string;
 		email?: string;
+		email_verified?: boolean;
 		name?: string;
 	};
 
-	if (!userInfo.email) return null;
+	// userinfo commonly omits email_verified; an absent claim is not verification.
+	const email = verifiedEmailFromClaims(userInfo);
+	if (!email) return null;
 
 	return {
-		email: userInfo.email,
-		name: userInfo.name || userInfo.email.split('@')[0],
+		email,
+		name: userInfo.name || email.split('@')[0],
 		providerId: userInfo.sub
 	};
 }

--- a/src/lib/server/oauth/verified-email.test.ts
+++ b/src/lib/server/oauth/verified-email.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { verifiedEmailFromClaims, verifiedGithubEmail } from './verified-email.js';
+
+describe('verifiedEmailFromClaims', () => {
+	it('accepts an email the provider states is verified', () => {
+		expect(verifiedEmailFromClaims({ email: 'a@x.com', email_verified: true })).toBe('a@x.com');
+	});
+
+	it('rejects an email the provider states is unverified', () => {
+		expect(verifiedEmailFromClaims({ email: 'a@x.com', email_verified: false })).toBeNull();
+	});
+
+	it('rejects when the claim is absent, rather than assuming verified', () => {
+		// An absent claim is not evidence of verification. Treating it as trusted is
+		// what let an unverified address claim an existing account.
+		expect(verifiedEmailFromClaims({ email: 'a@x.com' })).toBeNull();
+	});
+
+	it('rejects a truthy-but-not-true claim', () => {
+		// Some providers serialise the claim as a string. Only boolean true counts.
+		expect(verifiedEmailFromClaims({ email: 'a@x.com', email_verified: 'true' as never })).toBeNull();
+	});
+
+	it('rejects when there is no email at all', () => {
+		expect(verifiedEmailFromClaims({ email_verified: true })).toBeNull();
+		expect(verifiedEmailFromClaims({ email: '', email_verified: true })).toBeNull();
+	});
+
+	it('trims surrounding whitespace', () => {
+		expect(verifiedEmailFromClaims({ email: '  a@x.com  ', email_verified: true })).toBe('a@x.com');
+	});
+
+	it('rejects an address that is only whitespace', () => {
+		expect(verifiedEmailFromClaims({ email: '   ', email_verified: true })).toBeNull();
+	});
+});
+
+describe('verifiedGithubEmail', () => {
+	it('prefers the primary verified address', () => {
+		expect(
+			verifiedGithubEmail([
+				{ email: 'other@x.com', primary: false, verified: true },
+				{ email: 'primary@x.com', primary: true, verified: true }
+			])
+		).toBe('primary@x.com');
+	});
+
+	it('falls back to any verified address when the primary is unverified', () => {
+		expect(
+			verifiedGithubEmail([
+				{ email: 'primary@x.com', primary: true, verified: false },
+				{ email: 'other@x.com', primary: false, verified: true }
+			])
+		).toBe('other@x.com');
+	});
+
+	it('rejects an unverified primary rather than trusting it', () => {
+		expect(verifiedGithubEmail([{ email: 'primary@x.com', primary: true, verified: false }])).toBeNull();
+	});
+
+	it('returns null for an empty list', () => {
+		expect(verifiedGithubEmail([])).toBeNull();
+	});
+
+	it('ignores entries with a blank address', () => {
+		expect(
+			verifiedGithubEmail([
+				{ email: '   ', primary: true, verified: true },
+				{ email: 'real@x.com', primary: false, verified: true }
+			])
+		).toBe('real@x.com');
+	});
+
+	it('trims the address it returns', () => {
+		expect(verifiedGithubEmail([{ email: ' a@x.com ', primary: true, verified: true }])).toBe('a@x.com');
+	});
+});

--- a/src/lib/server/oauth/verified-email.ts
+++ b/src/lib/server/oauth/verified-email.ts
@@ -1,0 +1,52 @@
+/**
+ * Deciding whether an address an identity provider hands us is trustworthy enough
+ * to claim a Crumbs account.
+ *
+ * This matters because sign-in falls back to matching on the asserted address when
+ * no provider identity is on file: an address we accept here can log the bearer
+ * into whichever account already holds it. An IdP that lets a user set an arbitrary
+ * unverified address — the default posture of a self-hosted Keycloak or Authentik —
+ * could otherwise hand out someone else's account.
+ *
+ * Pure by design, and deliberately separate from the provider adapters, which reach
+ * the network and so cannot be exercised directly in a unit test.
+ */
+
+/** Non-empty trimmed form of `value`, or null. */
+function cleanAddress(value: string | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+/**
+ * The verified address from an OIDC-style claim set (Google and generic OIDC), or
+ * null if there isn't one.
+ *
+ * An absent `email_verified` yields null rather than being treated as verified: a
+ * missing claim is not evidence, and OIDC's userinfo response frequently omits it.
+ * The comparison is strictly against `true`, since some providers serialise the
+ * claim as the string `"true"`, which is truthy but says nothing we checked.
+ */
+export function verifiedEmailFromClaims(claims: {
+	email?: string;
+	email_verified?: boolean;
+}): string | null {
+	if (claims.email_verified !== true) return null;
+	return cleanAddress(claims.email);
+}
+
+/**
+ * The verified address from GitHub's `/user/emails` list, preferring the primary
+ * one, or null if none is verified.
+ *
+ * GitHub's `/user` profile also carries an `email`, but with no verification flag
+ * beside it, so it is not usable for this decision — this list is the only source
+ * that says whether GitHub actually confirmed the address.
+ */
+export function verifiedGithubEmail(
+	emails: { email: string; primary: boolean; verified: boolean }[]
+): string | null {
+	const verified = emails.filter((entry) => entry.verified && cleanAddress(entry.email));
+	const chosen = verified.find((entry) => entry.primary) ?? verified[0];
+	return chosen ? cleanAddress(chosen.email) : null;
+}


### PR DESCRIPTION
## The problem

OAuth sign-in falls back to matching on **the email address the identity provider asserts** when no provider identity is on file (`findOrLinkOAuthUser`). That fallback checked nothing — no verification claim, and no restriction on whether the target account already belonged to a different identity — and the callback then mints a session unconditionally.

So on an instance with OAuth configured, anyone who can get the configured IdP to assert another user's address is signed in as that user, admins included. `grep -rn email_verified src/` previously returned nothing.

The realistic route is a self-hosted Keycloak or Authentik where users may edit their own email and verification isn't enforced — the default posture. With Google or GitHub you'd need to genuinely control an account at that address, which is much harder.

**It also persisted.** Linking overwrites the row's `provider_id`, nothing in the application can clear it, and the `provider + providerId` branch is tried first — so access survived changing the IdP-side email back, and survived revoking sessions. The only remedy was deleting the user, which cascades away all their notes.

**If you have no OAuth provider configured, none of this was reachable** — `getEnabledProviders()` returns empty and the path is dead code.

## The fix

**A new pure module for the trust decision.** `verified-email.ts` holds it, deliberately separate from the adapters, which reach the network and so can't be exercised in a unit test. Two details matter:

- An **absent** `email_verified` is rejected rather than assumed true. A missing claim is not evidence.
- The check is strictly `=== true`, because some providers serialise the claim as the string `"true"` — truthy, but nothing anyone verified.

**Google and OIDC** now require that claim, on both the ID-token path and the userinfo fallback.

**GitHub** always resolves the address through `/user/emails` and no longer trusts `/user`'s profile `email`, which carries no verification flag beside it. The previous code already filtered `primary && verified` — but only on the *fallback* path, so an account with a public profile email skipped the check entirely. The `user:email` scope was already requested, so the endpoint is available.

**`findOrLinkOAuthUser`** links by email only when the row has no provider identity. Invited accounts that have never signed in have `provider_id` NULL, so the documented invite flow is unaffected, and returning users continue to match on `provider + providerId`.

## What this deliberately does not close

An IdP able to assert an arbitrary **verified** address can still claim an invited account that has never signed in. That's inherent to inviting people by email address. Closing it would mean refusing to link onto accounts that already hold a password — which would remove the admin recovery route documented at `docs/AUTH.md:30`, and that trade wasn't worth making here.

## Verification

`pnpm check` 0 errors / 14 pre-existing warnings · `pnpm test:unit` **347 passed / 31 files** (from 334 / 30) · `pnpm test:e2e` **135 passed** · coverage **45.94 / 45.94 / 55.70 / 85.81** against floors of 42/42/50/82 — every metric above both its floor and the previous baseline, with the new module at **100% lines and branches**.

The 13 new tests cover the trust decision directly: verified accepted, unverified rejected, absent claim rejected, string `"true"` rejected, blank addresses rejected, GitHub's primary-verified preference and its fallback to any verified address.

## Context

Found while designing the fix for #78, but independent of it and far smaller. #78 remains open — it needs a schema migration that deletes credential material from live databases, and its design is banked in `feat/password-oauth-coexist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbqJcFofZSbhbGwUwZP3wU
