### PR TITLE
feat(auth): enable password login on OAuth-only accounts, with disable control

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ For a single-user app with multiple devices:
 See `src/lib/server/db/schema.ts` for the complete Drizzle schema.
 
 Key tables:
-- `users` - User accounts (password hash, OAuth provider link, role)
+- `users` - User accounts (password hash, `password_login_enabled`, OAuth provider link, role)
 - `sessions` - Auth sessions (30-day TTL)
 - `notes` - Core note data with version tracking
 - `tags` - Unique tag names

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -14,20 +14,20 @@ On first launch, Crumbs presents a setup screen to create the initial admin acco
 
 ### Admin password resets
 
-An admin can reset the password of any user other than themselves, provided that account signs in with a password. Crumbs generates the new password and shows it once in that user's row — copy it and pass it to the user out of band, because it is not stored anywhere and cannot be shown again once dismissed. If SMTP is configured Crumbs also tries to notify the user that their password was reset, but the attempt is best-effort: a delivery failure is logged on the server and never surfaced in the UI, so a successful reset is not evidence the user was told. The notification never contains the password.
+An admin can reset the password of any user other than themselves. Crumbs generates the new password and shows it once in that user's row — copy it and pass it to the user out of band, because it is not stored anywhere and cannot be shown again once dismissed. If SMTP is configured Crumbs also tries to notify the user that their password was reset, but the attempt is best-effort: a delivery failure is logged on the server and never surfaced in the UI, so a successful reset is not evidence the user was told. The notification never contains the password.
 
-The control appears on every row, but is unavailable in two cases, each stating its reason on the row:
+The control appears on every row, but is unavailable in two cases:
 
 - **Your own row** — change your own password in **Settings > Profile**, which verifies your current password first.
-- **An account that signs in via OAuth/SSO** — it has no password the login form would accept, so setting one would hand the user a credential that cannot work.
+- **While a generated password is still on screen** — dismiss it first if you need to generate another.
 
-It is also unavailable while a generated password is still on screen, and that case gives no reason — dismiss the password first if you need to generate another.
+A reset enables password login for that account if it was not already enabled — including OAuth-only accounts — without removing their SSO link. Both sign-in methods can coexist.
 
-A reset does not sign the user out. **Revoke all sessions** is a separate action on the same row and, like the reset, is not offered for your own account.
+A reset **revokes all of the user's sessions** — they must sign in again with the new password (or via OAuth if linked). **Disable password login** is a separate action on rows where password login is enabled; it clears the stored hash, turns off password login, and revokes all sessions. It is not offered on your own row.
 
 A displayed password is only good until that account's password changes again: any later reset — by another admin, or by the user themselves from **Settings > Profile** — silently invalidates one still on screen, and nothing marks it as stale. Separately, if Crumbs cannot confirm a reset it says so and shows the password anyway; keep that one, since it may or may not have been applied, and reset again if the user cannot sign in.
 
-> **No password recovery.** Crumbs has no forgot-password flow. An admin who forgets their own password cannot reset it themselves: the admin control excludes their own row, and the profile flow requires the current password. Another admin can reset you, so keep a second admin account as cheap insurance. Failing that, if an OAuth/SSO provider is configured and your account's email matches your identity there, signing in with that provider gets you back in without a password — at the cost of handing the account over to the provider permanently, after which your password no longer works. With no other admin and no provider configured, there is no way back in through the app.
+> **No password recovery.** Crumbs has no forgot-password flow. An admin who forgets their own password cannot reset it themselves: the admin control excludes their own row, and the profile flow requires the current password. Another admin can reset you, so keep a second admin account as cheap insurance. Failing that, if an OAuth/SSO provider is configured and your account's email matches your identity there, signing in with that provider gets you back in without a password. An admin can also enable password login on an OAuth-linked account via **Settings > Users**. With no other admin and no provider configured, there is no way back in through the app.
 
 ## OAuth / SSO
 
@@ -52,7 +52,7 @@ OAuth does **not** auto-create accounts. Users must be pre-created by an admin:
 
 After initial linking, the user is identified by their provider-specific ID (`sub` claim), so email changes on the provider side won't break login.
 
-Tick **OAuth-only (no password)** when creating these accounts — the provider is how they will sign in anyway. If you set a password instead, treat it as temporary: the first OAuth sign-in hands the account over to the provider, after which the password no longer works at the login form and the admin password reset is unavailable for that account.
+Tick **OAuth-only (no password)** when creating these accounts — the provider is how they will sign in. An admin can later enable password login via **Settings > Users** if the IdP becomes unavailable. If you set a password at invite time, it keeps working after the user's first OAuth sign-in — both methods coexist independently.
 
 ### Environment variables
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -143,9 +143,10 @@
 - Admin dashboard to create, list, and delete users
 - Assign roles (admin / user)
 - Reset another user's password — Crumbs generates a 20-character password and shows it once in that user's row, with a copy button; it cannot be shown again
-  - Only for accounts that sign in with a password — OAuth/SSO accounts show why the reset is unavailable
+  - Works for any account other than your own, including OAuth-only — the reset deliberately enables password login and revokes all sessions
+  - **Disable password login** turns off password auth, clears the hash, and revokes sessions (not offered on your own row)
   - Your own password is changed from Settings > Profile, not here
-  - A reset does not sign the user out — revoke their sessions separately to force a logout
+  - Use **Revoke all sessions** separately if you need to force a logout without changing credentials
 - Revoke all sessions (force logout) for any user other than yourself
 
 ### PWA / Offline-First

--- a/drizzle/0005_green_raider.sql
+++ b/drizzle/0005_green_raider.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users` ADD `password_login_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE `users` SET `password_login_enabled` = 1 WHERE `auth_provider` = 'password';

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1241 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a9370796-3530-46f7-a701-d2910836c639",
+  "prevId": "785b6b61-24b1-4350-b0ca-18946b41e2ad",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attachments_user_id_users_id_fk": {
+          "name": "attachments_user_id_users_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "attachments_note_id_notes_id_fk": {
+          "name": "attachments_note_id_notes_id_fk",
+          "tableFrom": "attachments",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "login_attempts": {
+      "name": "login_attempts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "login_attempts_ip_timestamp_idx": {
+          "name": "login_attempts_ip_timestamp_idx",
+          "columns": [
+            "ip",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_collaborators": {
+      "name": "note_collaborators",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_collaborators_unique": {
+          "name": "note_collaborators_unique",
+          "columns": [
+            "note_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "note_collaborators_user_id_idx": {
+          "name": "note_collaborators_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_collaborators_note_id_notes_id_fk": {
+          "name": "note_collaborators_note_id_notes_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_collaborators_user_id_users_id_fk": {
+          "name": "note_collaborators_user_id_users_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "note_collaborators_added_by_users_id_fk": {
+          "name": "note_collaborators_added_by_users_id_fk",
+          "tableFrom": "note_collaborators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_links": {
+      "name": "note_links",
+      "columns": {
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_links_source_idx": {
+          "name": "note_links_source_idx",
+          "columns": [
+            "source_note_id"
+          ],
+          "isUnique": false
+        },
+        "note_links_target_idx": {
+          "name": "note_links_target_idx",
+          "columns": [
+            "target_note_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_links_source_note_id_notes_id_fk": {
+          "name": "note_links_source_note_id_notes_id_fk",
+          "tableFrom": "note_links",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "source_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_links_target_note_id_notes_id_fk": {
+          "name": "note_links_target_note_id_notes_id_fk",
+          "tableFrom": "note_links",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "target_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_tags": {
+      "name": "note_tags",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_tags_note_id_idx": {
+          "name": "note_tags_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        },
+        "note_tags_tag_id_idx": {
+          "name": "note_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "note_tags_note_id_notes_id_fk": {
+          "name": "note_tags_note_id_notes_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_tags_tag_id_tags_id_fk": {
+          "name": "note_tags_tag_id_tags_id_fk",
+          "tableFrom": "note_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_user_state": {
+      "name": "note_user_state",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "note_user_state_unique": {
+          "name": "note_user_state_unique",
+          "columns": [
+            "note_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "note_user_state_note_id_notes_id_fk": {
+          "name": "note_user_state_note_id_notes_id_fk",
+          "tableFrom": "note_user_state",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "note_user_state_user_id_users_id_fk": {
+          "name": "note_user_state_user_id_users_id_fk",
+          "tableFrom": "note_user_state",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "note_versions": {
+      "name": "note_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "checklist_mode": {
+          "name": "checklist_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_versions_note_id_idx": {
+          "name": "note_versions_note_id_idx",
+          "columns": [
+            "note_id"
+          ],
+          "isUnique": false
+        },
+        "note_versions_note_id_version_unique": {
+          "name": "note_versions_note_id_version_unique",
+          "columns": [
+            "note_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "note_versions_note_id_notes_id_fk": {
+          "name": "note_versions_note_id_notes_id_fk",
+          "tableFrom": "note_versions",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trashed": {
+          "name": "trashed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trashed_at": {
+          "name": "trashed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checklist_mode": {
+          "name": "checklist_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "notes_user_id_idx": {
+          "name": "notes_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "notes_trashed_archived_idx": {
+          "name": "notes_trashed_archived_idx",
+          "columns": [
+            "trashed",
+            "archived"
+          ],
+          "isUnique": false
+        },
+        "notes_updated_at_idx": {
+          "name": "notes_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notes_user_id_users_id_fk": {
+          "name": "notes_user_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shared_notes": {
+      "name": "shared_notes",
+      "columns": {
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "shared_notes_token_unique": {
+          "name": "shared_notes_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "shared_notes_note_id_notes_id_fk": {
+          "name": "shared_notes_note_id_notes_id_fk",
+          "tableFrom": "shared_notes",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_log": {
+      "name": "sync_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sync_log_timestamp_idx": {
+          "name": "sync_log_timestamp_idx",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sync_log_user_id_users_id_fk": {
+          "name": "sync_log_user_id_users_id_fk",
+          "tableFrom": "sync_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sync_log_note_id_notes_id_fk": {
+          "name": "sync_log_note_id_notes_id_fk",
+          "tableFrom": "sync_log",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_user_unique": {
+          "name": "tags_name_user_unique",
+          "columns": [
+            "name",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_preferences_user_key_unique": {
+          "name": "user_preferences_user_key_unique",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_login_enabled": {
+          "name": "password_login_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "auth_provider": {
+          "name": "auth_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'password'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785824271578,
       "tag": "0004_violet_nicolaos",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1787064677945,
+      "tag": "0005_green_raider",
+      "breakpoints": true
     }
   ]
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,7 +29,14 @@ export default defineConfig({
 		}
 	],
 	webServer: {
-		command: 'pnpm preview --port 4173',
+		// The wipe runs here (before the server opens the database), not in
+		// globalSetup: Playwright starts the webServer before globalSetup, so
+		// deleting the SQLite files later would orphan the server's open
+		// database onto a deleted inode. Tests that read the database file
+		// directly (see linkUserToOAuth in admin-users.spec.ts) must see the
+		// server's real database file.
+		command:
+			'rm -f data/test-crumbs.db data/test-crumbs.db-wal data/test-crumbs.db-shm data/test-crumbs.db-journal && pnpm preview --port 4173',
 		port: 4173,
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,

--- a/src/lib/server/auth.test.ts
+++ b/src/lib/server/auth.test.ts
@@ -6,6 +6,13 @@ import * as argon2 from 'argon2';
 import { randomBytes, randomUUID } from 'crypto';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type * as schema from './db/schema.js';
+import {
+	verifyPassword,
+	resetPassword,
+	findOrLinkOAuthUser,
+	createUser,
+	disablePasswordLogin
+} from './auth.js';
 
 let db: BetterSQLite3Database<typeof schema>;
 
@@ -123,5 +130,117 @@ describe('Auth - Sessions', () => {
 		await db.delete(sessions).where(eq(sessions.id, token));
 		const session = await db.select().from(sessions).where(eq(sessions.id, token)).get();
 		expect(session).toBeUndefined();
+	});
+});
+
+describe('Auth - password login enabled', () => {
+	it('verifyPassword succeeds when password login is enabled', async () => {
+		const password = randomUUID();
+		const hash = await argon2.hash(password);
+		await db.insert(users).values({
+			email: 'pw@test.com',
+			displayName: 'PW User',
+			passwordHash: hash,
+			passwordLoginEnabled: true,
+			authProvider: 'password',
+			createdAt: new Date()
+		});
+
+		const user = await verifyPassword('pw@test.com', password, db);
+		expect(user?.email).toBe('pw@test.com');
+	});
+
+	it('verifyPassword rejects when password login is disabled even with a hash', async () => {
+		const password = randomUUID();
+		const hash = await argon2.hash(password);
+		await db.insert(users).values({
+			email: 'oauth@test.com',
+			displayName: 'OAuth User',
+			passwordHash: hash,
+			passwordLoginEnabled: false,
+			authProvider: 'google',
+			providerId: 'gid-1',
+			createdAt: new Date()
+		});
+
+		expect(await verifyPassword('oauth@test.com', password, db)).toBeNull();
+	});
+
+	it('resetPassword enables password login on an OAuth-only account', async () => {
+		const [row] = await db
+			.insert(users)
+			.values({
+				email: 'enable@test.com',
+				displayName: 'Enable',
+				passwordLoginEnabled: false,
+				authProvider: 'none',
+				createdAt: new Date()
+			})
+			.returning();
+
+		const newPassword = randomUUID();
+		await resetPassword(row.id, newPassword, db);
+
+		const updated = await db.select().from(users).where(eq(users.id, row.id)).get();
+		expect(updated?.passwordLoginEnabled).toBe(true);
+		expect(await argon2.verify(updated!.passwordHash!, newPassword)).toBe(true);
+		expect(await verifyPassword('enable@test.com', newPassword, db)).not.toBeNull();
+	});
+
+	it('findOrLinkOAuthUser preserves password login when linking SSO', async () => {
+		const password = randomUUID();
+		const hash = await argon2.hash(password);
+		await db.insert(users).values({
+			email: 'both@test.com',
+			displayName: 'Both',
+			passwordHash: hash,
+			passwordLoginEnabled: true,
+			authProvider: 'password',
+			createdAt: new Date()
+		});
+
+		const linked = findOrLinkOAuthUser('google', 'google-id-1', 'both@test.com', 'Both', db);
+		expect(linked?.authProvider).toBe('google');
+		expect(linked?.passwordLoginEnabled).toBe(true);
+		expect(await verifyPassword('both@test.com', password, db)).not.toBeNull();
+	});
+
+	it('createUser sets passwordLoginEnabled from whether a password was given', async () => {
+		const withPassword = await createUser('a@test.com', 'A', 'password123', 'user', db);
+		expect(withPassword.passwordLoginEnabled).toBe(true);
+
+		const oauthOnly = await createUser('b@test.com', 'B', null, 'user', db);
+		expect(oauthOnly.passwordLoginEnabled).toBe(false);
+	});
+
+	it('disablePasswordLogin clears the hash, disables login, and removes sessions', async () => {
+		const password = randomUUID();
+		const hash = await argon2.hash(password);
+		const [row] = await db
+			.insert(users)
+			.values({
+				email: 'disable@test.com',
+				displayName: 'Disable',
+				passwordHash: hash,
+				passwordLoginEnabled: true,
+				authProvider: 'password',
+				createdAt: new Date()
+			})
+			.returning();
+
+		const token = randomBytes(32).toString('hex');
+		await db.insert(sessions).values({
+			id: token,
+			userId: row.id,
+			expiresAt: new Date(Date.now() + 86400000)
+		});
+
+		disablePasswordLogin(row.id, db);
+
+		const updated = await db.select().from(users).where(eq(users.id, row.id)).get();
+		expect(updated?.passwordLoginEnabled).toBe(false);
+		expect(updated?.passwordHash).toBeNull();
+		expect(await verifyPassword('disable@test.com', password, db)).toBeNull();
+		expect(await db.select().from(sessions).where(eq(sessions.userId, row.id)).all()).toHaveLength(0);
 	});
 });

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,4 +1,4 @@
-import { db, sqlite } from './db/index.js';
+import { db, sqlite, type Db } from './db/index.js';
 import { users, sessions } from './db/schema.js';
 import { eq, lt, and } from 'drizzle-orm';
 import * as argon2 from 'argon2';
@@ -16,6 +16,7 @@ function toUser(row: typeof users.$inferSelect): User {
 		displayName: row.displayName,
 		role: row.role,
 		authProvider: row.authProvider,
+		passwordLoginEnabled: row.passwordLoginEnabled,
 		providerId: row.providerId,
 		createdAt: row.createdAt
 	};
@@ -29,19 +30,21 @@ export async function isSetupComplete(): Promise<boolean> {
 export async function setupUser(
 	email: string,
 	password: string,
-	displayName?: string
+	displayName?: string,
+	dbInstance: Db = db
 ): Promise<User | null> {
-	const existing = db.select().from(users).get();
+	const existing = dbInstance.select().from(users).get();
 	if (existing) return null; // Already set up
 
 	const hash = await argon2.hash(password);
-	const result = db
+	const result = dbInstance
 		.insert(users)
 		.values({
 			email,
 			displayName: displayName || email.split('@')[0] || 'Admin',
 			role: 'admin',
 			passwordHash: hash,
+			passwordLoginEnabled: true,
 			authProvider: 'password',
 			createdAt: new Date()
 		})
@@ -52,12 +55,13 @@ export async function setupUser(
 
 export async function verifyPassword(
 	email: string,
-	password: string
+	password: string,
+	dbInstance: Db = db
 ): Promise<User | null> {
-	const user = db
+	const user = dbInstance
 		.select()
 		.from(users)
-		.where(and(eq(users.email, email), eq(users.authProvider, 'password')))
+		.where(and(eq(users.email, email), eq(users.passwordLoginEnabled, true)))
 		.get();
 	if (!user || !user.passwordHash) return null;
 
@@ -195,16 +199,18 @@ export async function createUser(
 	email: string,
 	displayName: string,
 	password: string | null,
-	role: 'admin' | 'user' = 'user'
+	role: 'admin' | 'user' = 'user',
+	dbInstance: Db = db
 ): Promise<User> {
 	const hash = password ? await argon2.hash(password) : null;
-	const result = db
+	const result = dbInstance
 		.insert(users)
 		.values({
 			email,
 			displayName,
 			role,
 			passwordHash: hash,
+			passwordLoginEnabled: !!password,
 			authProvider: password ? 'password' : 'none',
 			createdAt: new Date()
 		})
@@ -282,7 +288,7 @@ export async function changePassword(
 	newPassword: string
 ): Promise<boolean> {
 	const user = db.select().from(users).where(eq(users.id, userId)).get();
-	if (!user || !user.passwordHash) return false;
+	if (!user || !user.passwordHash || !user.passwordLoginEnabled) return false;
 
 	const valid = await argon2.verify(user.passwordHash, currentPassword);
 	if (!valid) return false;
@@ -292,9 +298,26 @@ export async function changePassword(
 	return true;
 }
 
-export async function resetPassword(userId: number, newPassword: string): Promise<void> {
+export async function resetPassword(
+	userId: number,
+	newPassword: string,
+	dbInstance: Db = db
+): Promise<void> {
 	const hash = await argon2.hash(newPassword);
-	db.update(users).set({ passwordHash: hash }).where(eq(users.id, userId)).run();
+	dbInstance
+		.update(users)
+		.set({ passwordHash: hash, passwordLoginEnabled: true })
+		.where(eq(users.id, userId))
+		.run();
+}
+
+export function disablePasswordLogin(userId: number, dbInstance: Db = db): void {
+	dbInstance
+		.update(users)
+		.set({ passwordHash: null, passwordLoginEnabled: false })
+		.where(eq(users.id, userId))
+		.run();
+	dbInstance.delete(sessions).where(eq(sessions.userId, userId)).run();
 }
 
 export function updateUserRole(userId: number, role: 'admin' | 'user'): void {
@@ -303,15 +326,17 @@ export function updateUserRole(userId: number, role: 'admin' | 'user'): void {
 
 /**
  * Find a user by OAuth provider, or by email. Invite-only: rejects if no matching user.
+ * Linking OAuth updates the provider fields only — password login stays as configured.
  */
 export function findOrLinkOAuthUser(
 	provider: string,
 	providerId: string,
 	email: string,
-	name: string
+	name: string,
+	dbInstance: Db = db
 ): User | null {
 	// First try exact provider+providerId match
-	const byProvider = db
+	const byProvider = dbInstance
 		.select()
 		.from(users)
 		.where(and(eq(users.authProvider, provider), eq(users.providerId, providerId)))
@@ -319,11 +344,12 @@ export function findOrLinkOAuthUser(
 	if (byProvider) return toUser(byProvider);
 
 	// Try matching by email (invite-only: user must already exist)
-	const byEmail = db.select().from(users).where(eq(users.email, email)).get();
+	const byEmail = dbInstance.select().from(users).where(eq(users.email, email)).get();
 	if (!byEmail) return null; // No matching user — not invited
 
-	// Link this OAuth provider to the existing user
-	db.update(users)
+	// Link this OAuth provider to the existing user without touching password login.
+	dbInstance
+		.update(users)
 		.set({ authProvider: provider, providerId, displayName: byEmail.displayName || name })
 		.where(eq(users.id, byEmail.id))
 		.run();

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -28,6 +28,7 @@ sqlite.exec(`
 		display_name TEXT NOT NULL DEFAULT '',
 		role TEXT NOT NULL DEFAULT 'user',
 		password_hash TEXT,
+		password_login_enabled INTEGER NOT NULL DEFAULT 0,
 		auth_provider TEXT NOT NULL DEFAULT 'password',
 		provider_id TEXT,
 		created_at INTEGER NOT NULL
@@ -269,15 +270,30 @@ if (pwCol && pwCol.notnull) {
 			display_name TEXT NOT NULL DEFAULT '',
 			role TEXT NOT NULL DEFAULT 'user',
 			password_hash TEXT,
+			password_login_enabled INTEGER NOT NULL DEFAULT 0,
 			auth_provider TEXT NOT NULL DEFAULT 'password',
 			provider_id TEXT,
 			created_at INTEGER NOT NULL
 		);
-		INSERT INTO __new_users(id, email, display_name, role, password_hash, auth_provider, provider_id, created_at)
-			SELECT id, email, display_name, role, password_hash, auth_provider, provider_id, created_at FROM users;
+		INSERT INTO __new_users(id, email, display_name, role, password_hash, password_login_enabled, auth_provider, provider_id, created_at)
+			SELECT id, email, display_name, role, password_hash,
+				CASE WHEN auth_provider = 'password' THEN 1 ELSE 0 END,
+				auth_provider, provider_id, created_at FROM users;
 		DROP TABLE users;
 		ALTER TABLE __new_users RENAME TO users;
 	`);
+}
+
+// Migration: add password_login_enabled (independent of OAuth provider)
+const userColumnsAfterPw = sqlite
+	.prepare("PRAGMA table_info('users')")
+	.all() as { name: string }[];
+if (!userColumnsAfterPw.some((col) => col.name === 'password_login_enabled')) {
+	sqlite.exec(`ALTER TABLE users ADD COLUMN password_login_enabled INTEGER NOT NULL DEFAULT 0;`);
+	// Backfill: only accounts whose sign-in method was password keep it enabled.
+	// OAuth-linked rows may carry a legacy hash; leaving them disabled avoids
+	// silently widening access — an admin reset is the deliberate enable act.
+	sqlite.exec(`UPDATE users SET password_login_enabled = 1 WHERE auth_provider = 'password';`);
 }
 
 // Re-enable foreign keys

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -6,6 +6,9 @@ export const users = sqliteTable('users', {
 	displayName: text('display_name').notNull().default(''),
 	role: text('role', { enum: ['admin', 'user'] }).notNull().default('user'),
 	passwordHash: text('password_hash'),
+	passwordLoginEnabled: integer('password_login_enabled', { mode: 'boolean' })
+		.notNull()
+		.default(false),
 	authProvider: text('auth_provider').notNull().default('password'),
 	providerId: text('provider_id'),
 	createdAt: integer('created_at', { mode: 'timestamp' }).notNull()

--- a/src/lib/server/db/test-helpers.ts
+++ b/src/lib/server/db/test-helpers.ts
@@ -19,6 +19,7 @@ export function createTestDb(options?: { seedUser?: boolean }) {
 			display_name TEXT NOT NULL DEFAULT '',
 			role TEXT NOT NULL DEFAULT 'user',
 			password_hash TEXT,
+			password_login_enabled INTEGER NOT NULL DEFAULT 0,
 			auth_provider TEXT NOT NULL DEFAULT 'password',
 			provider_id TEXT,
 			created_at INTEGER NOT NULL
@@ -173,6 +174,7 @@ export function createTestDb(options?: { seedUser?: boolean }) {
 			displayName: 'Test User',
 			role: 'admin',
 			authProvider: 'password',
+			passwordLoginEnabled: true,
 			createdAt: new Date()
 		}).run();
 	}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -75,6 +75,7 @@ export interface User {
 	displayName: string;
 	role: 'admin' | 'user';
 	authProvider: string;
+	passwordLoginEnabled: boolean;
 	providerId: string | null;
 	createdAt: Date;
 }

--- a/src/lib/utils/auth-methods.test.ts
+++ b/src/lib/utils/auth-methods.test.ts
@@ -1,91 +1,95 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { canResetPassword, passwordResetBlockedReason } from './auth-methods.js';
-
-const NON_PASSWORD_PROVIDERS = ['none', 'google', 'github', 'oidc'];
+import {
+	canResetPassword,
+	passwordResetBlockedReason,
+	requiresPasswordForAccountDeletion,
+	canDisablePasswordLogin
+} from './auth-methods.js';
 
 describe('canResetPassword', () => {
 	it('allows a reset for a password account', () => {
-		expect(canResetPassword({ authProvider: 'password' })).toBe(true);
+		expect(canResetPassword({ authProvider: 'password', passwordLoginEnabled: true })).toBe(true);
 	});
 
-	it('blocks a reset for every non-password provider', () => {
-		// verifyPassword() filters on authProvider === 'password', so a hash
-		// written for any other provider could never be used to sign in.
-		for (const authProvider of NON_PASSWORD_PROVIDERS) {
-			expect(canResetPassword({ authProvider }), authProvider).toBe(false);
-		}
+	it('allows a reset for an OAuth-only account', () => {
+		expect(canResetPassword({ authProvider: 'none', passwordLoginEnabled: false })).toBe(true);
 	});
 
-	it('blocks a reset for an unenumerated provider', () => {
-		expect(canResetPassword({ authProvider: 'saml' })).toBe(false);
-		expect(canResetPassword({ authProvider: '' })).toBe(false);
+	it('allows a reset for an OAuth-linked account', () => {
+		expect(canResetPassword({ authProvider: 'google', passwordLoginEnabled: true })).toBe(true);
 	});
 });
 
 describe('passwordResetBlockedReason', () => {
-	it('returns null for a password account', () => {
-		expect(passwordResetBlockedReason({ authProvider: 'password' })).toBeNull();
-	});
-
-	it('names the provider in the reason', () => {
-		expect(passwordResetBlockedReason({ authProvider: 'none' })).toBe(
-			'This account has no password — it signs in via OAuth.'
-		);
-		expect(passwordResetBlockedReason({ authProvider: 'google' })).toBe(
-			'Managed by Google — password login is disabled for this account.'
-		);
-		expect(passwordResetBlockedReason({ authProvider: 'github' })).toBe(
-			'Managed by GitHub — password login is disabled for this account.'
-		);
-		expect(passwordResetBlockedReason({ authProvider: 'oidc' })).toBe(
-			'Managed by SSO — password login is disabled for this account.'
-		);
-	});
-
-	it('falls back to a generic reason for an unenumerated provider', () => {
-		expect(passwordResetBlockedReason({ authProvider: 'saml' })).toBe(
-			'Password login is not available for this account.'
-		);
-	});
-
-	it('always explains a blocked reset', () => {
-		// authProvider is typed `string`, so no missing branch can be caught by
-		// the compiler. A null reason here would render a disabled control with
-		// no explanation — the confusion issue #77 reported.
-		//
-		// The Object.prototype keys are the interesting cases: with a plain object
-		// literal as the lookup table they resolve to inherited members, so a
-		// nullish fallback never fires and the function returns a function or an
-		// object in place of its declared string. Asserting typeof rather than
-		// truthiness is what catches that.
-		const providers = [
-			...NON_PASSWORD_PROVIDERS,
-			'saml',
-			'',
-			'PASSWORD',
-			'ldap',
-			'unknown',
-			'__proto__',
-			'toString',
-			'constructor',
-			'hasOwnProperty',
-			'valueOf'
-		];
-		for (const authProvider of providers) {
-			const user = { authProvider };
-			expect(canResetPassword(user), authProvider).toBe(false);
-			const reason = passwordResetBlockedReason(user);
-			expect(typeof reason, authProvider).toBe('string');
-			expect(reason, authProvider).not.toBe('');
+	it('returns null for every account type', () => {
+		for (const user of [
+			{ authProvider: 'password', passwordLoginEnabled: true },
+			{ authProvider: 'none', passwordLoginEnabled: false },
+			{ authProvider: 'google', passwordLoginEnabled: true },
+			{ authProvider: 'oidc', passwordLoginEnabled: false }
+		]) {
+			expect(passwordResetBlockedReason(user)).toBeNull();
 		}
 	});
 });
 
-describe('auth-methods module', () => {
-	it('does not use Math.random', () => {
-		// The reset-eligibility rule must be pure and deterministic.
-		const source = readFileSync(new URL('./auth-methods.ts', import.meta.url), 'utf8');
-		expect(source).not.toContain('Math.random');
+describe('requiresPasswordForAccountDeletion', () => {
+	it('requires password for a pure password account', () => {
+		expect(
+			requiresPasswordForAccountDeletion({ authProvider: 'password', passwordLoginEnabled: true })
+		).toBe(true);
+	});
+
+	it('requires password for OAuth-only with admin-enabled password login', () => {
+		expect(
+			requiresPasswordForAccountDeletion({ authProvider: 'none', passwordLoginEnabled: true })
+		).toBe(true);
+	});
+
+	it('does not require password for OAuth-linked accounts even when password login is enabled', () => {
+		for (const authProvider of ['google', 'github', 'oidc']) {
+			expect(
+				requiresPasswordForAccountDeletion({ authProvider, passwordLoginEnabled: true }),
+				authProvider
+			).toBe(false);
+		}
+	});
+
+	it('does not require password for OAuth-only without password login', () => {
+		expect(
+			requiresPasswordForAccountDeletion({ authProvider: 'none', passwordLoginEnabled: false })
+		).toBe(false);
+	});
+});
+
+describe('canDisablePasswordLogin', () => {
+	it('allows disabling for an OAuth-linked user with password login enabled', () => {
+		expect(
+			canDisablePasswordLogin({ id: 2, passwordLoginEnabled: true, authProvider: 'google' }, 1)
+		).toBe(true);
+	});
+
+	it('blocks disabling on the admin own row', () => {
+		expect(
+			canDisablePasswordLogin({ id: 1, passwordLoginEnabled: true, authProvider: 'google' }, 1)
+		).toBe(false);
+	});
+
+	it('blocks disabling when password login is already off', () => {
+		expect(
+			canDisablePasswordLogin({ id: 2, passwordLoginEnabled: false, authProvider: 'google' }, 1)
+		).toBe(false);
+	});
+
+	it('blocks disabling on a password-only account', () => {
+		expect(
+			canDisablePasswordLogin({ id: 2, passwordLoginEnabled: true, authProvider: 'password' }, 1)
+		).toBe(false);
+	});
+
+	it('blocks disabling on OAuth-only with admin-enabled password but no provider link', () => {
+		expect(
+			canDisablePasswordLogin({ id: 2, passwordLoginEnabled: true, authProvider: 'none' }, 1)
+		).toBe(false);
 	});
 });

--- a/src/lib/utils/auth-methods.ts
+++ b/src/lib/utils/auth-methods.ts
@@ -1,44 +1,51 @@
 import type { User } from '$lib/types/index.js';
 
 /**
- * Human-readable reason a password reset is unavailable, keyed by auth provider.
- * Anything absent from this map falls back to BLOCKED_REASON_FALLBACK, so the
- * blocked path can never be left unexplained.
- *
- * A Map, not an object literal: an object inherits Object.prototype, so a lookup
- * for 'toString' or '__proto__' would resolve to an inherited member instead of
- * missing, and the fallback below would never fire. A Map has no such keys, so
- * totality holds by construction rather than by a guard that could be dropped.
- */
-const BLOCKED_REASONS = new Map<string, string>([
-	['none', 'This account has no password — it signs in via OAuth.'],
-	['google', 'Managed by Google — password login is disabled for this account.'],
-	['github', 'Managed by GitHub — password login is disabled for this account.'],
-	['oidc', 'Managed by SSO — password login is disabled for this account.']
-]);
-
-const BLOCKED_REASON_FALLBACK = 'Password login is not available for this account.';
-
-/**
  * Whether an admin may set a new password for this account.
  *
- * Password login is gated on `authProvider` — verifyPassword() only matches rows
- * where it equals 'password' — so writing a hash for any other provider stores a
- * credential that can never be used to sign in.
+ * Password login is gated on `passwordLoginEnabled`, which resetPassword() sets
+ * deliberately — so an admin can enable password auth on any account, including
+ * OAuth-only ones, without clearing their SSO link.
  */
-export function canResetPassword(user: Pick<User, 'authProvider'>): boolean {
-	return user.authProvider === 'password';
+export function canResetPassword(_user: Pick<User, 'passwordLoginEnabled' | 'authProvider'>): boolean {
+	return true;
 }
 
 /**
  * Why a password reset is blocked, or null when it is allowed.
  *
- * `authProvider` is typed `string`, so the compiler cannot enforce exhaustiveness
- * here. The fallback guarantees the invariant this module exists for: whenever
- * `canResetPassword` is false, this returns a non-empty explanation, so the UI
- * never shows a disabled control without saying why.
+ * Eligibility is checked in the UI for the signed-in admin's own row; every
+ * other account may receive a reset that enables password login.
  */
-export function passwordResetBlockedReason(user: Pick<User, 'authProvider'>): string | null {
-	if (canResetPassword(user)) return null;
-	return BLOCKED_REASONS.get(user.authProvider) ?? BLOCKED_REASON_FALLBACK;
+export function passwordResetBlockedReason(
+	_user: Pick<User, 'passwordLoginEnabled' | 'authProvider'>
+): string | null {
+	return null;
+}
+
+/**
+ * Whether self-service account deletion must verify the user's password.
+ *
+ * OAuth-linked accounts may delete with their active SSO session alone, even
+ * when an admin has enabled password login. Pure password accounts, and
+ * OAuth-only rows with password login enabled but no provider link, still
+ * require the password.
+ */
+export function requiresPasswordForAccountDeletion(
+	user: Pick<User, 'authProvider' | 'passwordLoginEnabled'>
+): boolean {
+	if (user.authProvider === 'password') return true;
+	if (user.authProvider === 'none' && user.passwordLoginEnabled) return true;
+	return false;
+}
+
+/** Whether an admin may turn off password login for this account. */
+export function canDisablePasswordLogin(
+	user: Pick<User, 'id' | 'passwordLoginEnabled' | 'authProvider'>,
+	adminId: number
+): boolean {
+	if (user.id === adminId || !user.passwordLoginEnabled) return false;
+	// Only when another sign-in method exists — disabling on a password-only row
+	// would lock the user out with no OAuth fallback.
+	return user.authProvider !== 'password' && user.authProvider !== 'none';
 }

--- a/src/routes/(app)/settings/users/+page.svelte
+++ b/src/routes/(app)/settings/users/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import type { User } from '$lib/types/index.js';
 	import PasswordStrengthMeter from '$lib/components/PasswordStrengthMeter.svelte';
-	import { canResetPassword, passwordResetBlockedReason } from '$lib/utils/auth-methods.js';
+	import { canResetPassword, passwordResetBlockedReason, canDisablePasswordLogin } from '$lib/utils/auth-methods.js';
 	import { generatePassword } from '$lib/utils/password.js';
 	import { tooltip } from '$lib/utils/tooltip.js';
 	import ShieldCheck from 'lucide-svelte/icons/shield-check';
 	import ShieldOff from 'lucide-svelte/icons/shield-off';
 	import KeyRound from 'lucide-svelte/icons/key-round';
+	import LockKeyhole from 'lucide-svelte/icons/lock-keyhole';
 	import LogOut from 'lucide-svelte/icons/log-out';
 	import Trash2 from 'lucide-svelte/icons/trash-2';
 	import LoaderCircle from 'lucide-svelte/icons/loader-circle';
@@ -331,6 +332,37 @@
 			// ignore
 		}
 	}
+
+	async function disablePasswordLogin(user: User) {
+		if (!canDisablePasswordLogin(user, data.user?.id ?? -1)) return;
+		if (
+			!confirm(
+				`Disable password login for ${userLabel(user)}? They will need to sign in via their linked OAuth provider. All sessions will be revoked.`
+			)
+		) {
+			return;
+		}
+		try {
+			const res = await fetch(`/api/admin/users/${user.id}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ disablePasswordLogin: true })
+			});
+			if (res.ok) {
+				const updated = await res.json();
+				users = users.map((u) => (u.id === user.id ? updated : u));
+				createMsg = `Password login disabled for ${userLabel(user)}`;
+				createError = false;
+			} else {
+				const d = await res.json().catch(() => ({}));
+				createMsg = d.message || 'Failed to disable password login';
+				createError = true;
+			}
+		} catch {
+			createMsg = 'Connection error';
+			createError = true;
+		}
+	}
 </script>
 
 <!-- Create User -->
@@ -468,6 +500,17 @@
 									<KeyRound class="h-4 w-4" />
 								{/if}
 							</button>
+							{#if canDisablePasswordLogin(user, data.user?.id ?? -1)}
+								<button
+									onclick={() => disablePasswordLogin(user)}
+									data-testid="disable-password-btn-{user.id}"
+									class="inline-flex size-11 items-center justify-center rounded-sm text-[var(--text-muted)] transition-colors duration-150 ease-out hover:bg-[var(--hover-wash)]/10"
+									use:tooltip={'Disable password login'}
+									aria-label="Disable password login"
+								>
+									<LockKeyhole class="h-4 w-4" />
+								</button>
+							{/if}
 							{#if user.id !== data.user?.id}
 								<button
 									onclick={() => revokeSessions(user)}

--- a/src/routes/api/admin/users/[id]/+server.ts
+++ b/src/routes/api/admin/users/[id]/+server.ts
@@ -1,9 +1,8 @@
 import { json, error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types.js';
 import { requireAdmin } from '$lib/server/api-utils.js';
-import { getUser, deleteUser, updateUserRole, resetPassword, revokeAllSessions } from '$lib/server/auth.js';
+import { getUser, deleteUser, updateUserRole, resetPassword, revokeAllSessions, disablePasswordLogin } from '$lib/server/auth.js';
 import { isEmailConfigured, sendPasswordResetEmail, sendRoleChangedEmail } from '$lib/server/email.js';
-import { canResetPassword, passwordResetBlockedReason } from '$lib/utils/auth-methods.js';
 
 export const PATCH: RequestHandler = async ({ params, request, ...event }) => {
 	const admin = requireAdmin(event);
@@ -40,21 +39,29 @@ export const PATCH: RequestHandler = async ({ params, request, ...event }) => {
 		if (userId === admin.id) {
 			throw error(400, 'Cannot reset your own password — change it from your profile instead');
 		}
-		// Refuse accounts that do not sign in with a password. resetPassword()
-		// writes only passwordHash, and verifyPassword() matches only rows whose
-		// authProvider is 'password' — a hash written here could never be used to
-		// sign in, while the email below would claim the reset worked. The reason
-		// text comes from the same module as the check, so this matches what the
-		// UI explains; the ?? only satisfies error()'s string parameter.
-		if (!canResetPassword(user)) {
-			throw error(400, passwordResetBlockedReason(user) ?? 'This account does not use password login');
-		}
 		await resetPassword(userId, body.newPassword);
+		revokeAllSessions(userId);
 
 		// Notify user of password reset (fire-and-forget)
 		if (isEmailConfigured() && user.email) {
 			sendPasswordResetEmail(user.email, user.displayName, origin).catch(() => {});
 		}
+	}
+
+	if (body.disablePasswordLogin) {
+		if (userId === admin.id) {
+			throw error(400, 'Cannot disable password login on your own account');
+		}
+		if (!user.passwordLoginEnabled) {
+			throw error(400, 'Password login is not enabled for this account');
+		}
+		if (user.authProvider === 'password' || user.authProvider === 'none') {
+			throw error(
+				400,
+				'Password login can only be disabled when the account is linked to OAuth'
+			);
+		}
+		disablePasswordLogin(userId);
 	}
 
 	if (body.revokeSessions) {

--- a/src/routes/api/auth/account/+server.ts
+++ b/src/routes/api/auth/account/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types.js';
 import { getUserId } from '$lib/server/api-utils.js';
 import { verifyPassword, deleteUser, deleteSession, getUser } from '$lib/server/auth.js';
 import { isEmailConfigured, sendAccountDeletedEmail } from '$lib/server/email.js';
+import { requiresPasswordForAccountDeletion } from '$lib/utils/auth-methods.js';
 
 export const DELETE: RequestHandler = async ({ request, cookies, ...event }) => {
 	const userId = getUserId(event);
@@ -11,8 +12,9 @@ export const DELETE: RequestHandler = async ({ request, cookies, ...event }) => 
 
 	const body = await request.json();
 
-	// OAuth users don't have passwords — allow deletion without password
-	if (user.authProvider === 'password') {
+	// Password required for pure password accounts; OAuth-linked accounts may delete
+	// with their active SSO session even when password login was admin-enabled.
+	if (requiresPasswordForAccountDeletion(user)) {
 		if (!body.password) throw error(400, 'Password is required');
 		const verified = await verifyPassword(user.email, body.password);
 		if (!verified) throw error(401, 'Invalid password');

--- a/static/api/openapi.json
+++ b/static/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Crumbs API",
     "description": "Auto-generated API spec for crumbs",
-    "version": "0.31.0",
+    "version": "0.33.0",
     "contact": {
       "name": "Bretzel",
       "url": "https://bretzel.app"

--- a/tests/e2e/admin-users.spec.ts
+++ b/tests/e2e/admin-users.spec.ts
@@ -3,12 +3,25 @@ import { randomUUID } from 'crypto';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import Database from 'better-sqlite3';
 import { TEST_CREDENTIALS_FILE } from './global-setup';
 
 const { userPassword } = JSON.parse(readFileSync(TEST_CREDENTIALS_FILE, 'utf-8'));
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEST_IMAGE_PATH = join(__dirname, 'helpers', 'test-image.png');
+const TEST_DB = './data/test-crumbs.db';
+
+/** Link a user row to an OAuth provider in the test database (simulates first SSO sign-in). */
+function linkUserToOAuth(userId: number, provider = 'google', providerId?: string): void {
+	const db = new Database(TEST_DB);
+	db.prepare('UPDATE users SET auth_provider = ?, provider_id = ? WHERE id = ?').run(
+		provider,
+		providerId ?? `test-${userId}`,
+		userId
+	);
+	db.close();
+}
 
 /** Create a victim user via the admin API, returning the user's id. */
 async function createVictim(
@@ -27,7 +40,7 @@ async function createVictim(
 /**
  * Create a victim user with no password via the admin API, returning the user's id.
  * Omitting the password is the OAuth-only path: createUser() stores authProvider
- * 'none', which verifyPassword() never matches.
+ * 'none' with passwordLoginEnabled false until an admin reset enables it.
  */
 async function createOAuthOnlyVictim(
 	page: import('@playwright/test').Page,
@@ -40,6 +53,7 @@ async function createOAuthOnlyVictim(
 	expect(res.status()).toBe(201);
 	const user = await res.json();
 	expect(user.authProvider).toBe('none');
+	expect(user.passwordLoginEnabled).toBe(false);
 	return user.id;
 }
 
@@ -213,7 +227,7 @@ test.describe.serial('Admin — Password Reset', () => {
 		await page.request.delete(`/api/admin/users/${victimId}`);
 	});
 
-	test('Scenario: An account that signs in via OAuth cannot be given a password', async ({
+	test('Scenario: An OAuth-only account can be given a password by an admin', async ({
 		authenticatedPage: page,
 		browser
 	}) => {
@@ -221,26 +235,88 @@ test.describe.serial('Admin — Password Reset', () => {
 		const email = 'oauth-only@test.com';
 		const victimId = await createOAuthOnlyVictim(page, email, 'OAuth Only');
 
-		// When the admin attempts to set a password for that account
-		const attemptedPassword = `attempt-${randomUUID()}`;
+		// When the admin sets a password for that account
+		const newPassword = `oauth-pw-${randomUUID()}`;
 		const res = await page.request.patch(`/api/admin/users/${victimId}`, {
-			data: { newPassword: attemptedPassword }
+			data: { newPassword }
 		});
 
-		// Then the attempt is rejected and the response says why
-		expect(res.status()).toBe(400);
-		const body = await res.json();
-		expect(body.message).toMatch(/OAuth|password login/i);
+		// Then the reset succeeds and enables password login
+		expect(res.status()).toBe(200);
+		const updated = await res.json();
+		expect(updated.passwordLoginEnabled).toBe(true);
 
-		// And the account still cannot sign in with the attempted password.
-		// This is the positive control for the rejection above: it confirms no
-		// usable credential was stored, not merely that the request 400'd.
+		// And the account can sign in with the new password while keeping OAuth
 		const ctx = await browser.newContext();
 		const loginRes = await ctx.request.post('/api/auth/login', {
-			data: { email, password: attemptedPassword }
+			data: { email, password: newPassword }
 		});
-		expect(loginRes.status()).toBe(401);
+		expect(loginRes.status()).toBe(200);
 		await ctx.close();
+
+		// Clean up
+		await page.request.delete(`/api/admin/users/${victimId}`);
+	});
+
+	test('Scenario: A password reset revokes all existing sessions', async ({
+		authenticatedPage: page,
+		browser
+	}) => {
+		// Given a password-auth user with an active session
+		const email = 'revoke-on-reset@test.com';
+		const victimId = await createVictim(page, email, 'Revoke Reset');
+		const ctx = await browser.newContext();
+		const loginRes = await ctx.request.post('/api/auth/login', {
+			data: { email, password: userPassword }
+		});
+		expect(loginRes.status()).toBe(200);
+
+		// When the admin sets a new password for that account
+		const newPassword = `revoke-${randomUUID()}`;
+		const resetRes = await page.request.patch(`/api/admin/users/${victimId}`, {
+			data: { newPassword }
+		});
+		expect(resetRes.status()).toBe(200);
+
+		// Then the old session is no longer valid
+		expect((await ctx.request.get('/api/notes')).status()).toBe(401);
+		await ctx.close();
+
+		// And the new password still works
+		const fresh = await browser.newContext();
+		expect(
+			(
+				await fresh.request.post('/api/auth/login', {
+					data: { email, password: newPassword }
+				})
+			).status()
+		).toBe(200);
+		await fresh.close();
+
+		// Clean up
+		await page.request.delete(`/api/admin/users/${victimId}`);
+	});
+
+	test('Scenario: An admin can disable password login on an OAuth-linked user', async ({
+		authenticatedPage: page
+	}) => {
+		// Given an OAuth-linked user with password login enabled
+		const email = 'disable-pw@test.com';
+		const victimId = await createVictim(page, email, 'Disable Pw');
+		linkUserToOAuth(victimId);
+
+		// When the admin disables password login for that account
+		const res = await page.request.patch(`/api/admin/users/${victimId}`, {
+			data: { disablePasswordLogin: true }
+		});
+
+		// Then password login is off and the old password no longer works
+		expect(res.status()).toBe(200);
+		expect((await res.json()).passwordLoginEnabled).toBe(false);
+		expect(
+			(await page.request.post('/api/auth/login', { data: { email, password: userPassword } }))
+				.status()
+		).toBe(401);
 
 		// Clean up
 		await page.request.delete(`/api/admin/users/${victimId}`);
@@ -314,6 +390,7 @@ async function resetViaUi(
 const ROW_ACTION_LABELS = [
 	'Promote to admin',
 	'Reset password',
+	'Disable password login',
 	'Revoke all sessions',
 	'Delete user'
 ] as const;
@@ -341,23 +418,14 @@ test.describe('Admin — Password Reset UI', () => {
 			await expect(page.getByTestId(`reset-password-btn-${id}`)).toBeVisible();
 		}
 
-		// And it is available for the password-auth account
-		await expect(page.getByTestId(`reset-password-btn-${eligibleId}`)).toHaveAttribute(
-			'aria-disabled',
-			'false'
-		);
-		await expect(page.getByTestId(`reset-password-reason-${eligibleId}`)).toHaveCount(0);
-
-		// And the OAuth-only account explains in visible text why it is unavailable
-		const oauthBtn = page.getByTestId(`reset-password-btn-${oauthId}`);
-		await expect(oauthBtn).toHaveAttribute('aria-disabled', 'true');
-		const oauthReason = page.getByTestId(`reset-password-reason-${oauthId}`);
-		await expect(oauthReason).toBeVisible();
-		await expect(oauthReason).toContainText(/OAuth|password login/i);
-		await expect(oauthBtn).toHaveAttribute(
-			'aria-describedby',
-			`reset-password-reason-${oauthId}`
-		);
+		// And it is available for both password and OAuth-only accounts
+		for (const id of [eligibleId, oauthId]) {
+			await expect(page.getByTestId(`reset-password-btn-${id}`)).toHaveAttribute(
+				'aria-disabled',
+				'false'
+			);
+			await expect(page.getByTestId(`reset-password-reason-${id}`)).toHaveCount(0);
+		}
 
 		// And the admin's own row points them at their profile instead
 		const ownBtn = page.getByTestId(`reset-password-btn-${adminId}`);
@@ -365,19 +433,13 @@ test.describe('Admin — Password Reset UI', () => {
 		await expect(page.getByTestId(`reset-password-reason-${adminId}`)).toContainText(/Profile/i);
 
 		// And an unavailable control stays reachable by keyboard
-		for (const btn of [oauthBtn, ownBtn]) {
-			await expect(btn).not.toHaveAttribute('disabled', /.*/);
-			await btn.focus();
-			await expect(btn).toBeFocused();
-		}
+		await expect(ownBtn).not.toHaveAttribute('disabled', /.*/);
+		await ownBtn.focus();
+		await expect(ownBtn).toBeFocused();
 
-		// And activating an unavailable control changes nothing. force: true skips
-		// Playwright's own aria-disabled actionability check, so what is under test is
-		// the handler refusing the activation, not the harness declining to send it.
+		// And activating the admin's own control changes nothing
 		await ownBtn.click({ force: true });
-		await oauthBtn.click({ force: true });
 		await expect(page.getByTestId(`generated-password-${adminId}`)).toHaveCount(0);
-		await expect(page.getByTestId(`generated-password-${oauthId}`)).toHaveCount(0);
 		expect(patchedIds).toEqual([]);
 
 		// Clean up
@@ -630,15 +692,19 @@ test.describe('Admin — Password Reset UI', () => {
 	test('Scenario: Row actions stay full-size square targets at every phone width', async ({
 		authenticatedPage: page
 	}) => {
-		// Given a password-auth user, whose row therefore offers all four actions
+		// Given an OAuth-linked user, whose row therefore offers all five actions
+		// (the disable-password control is only offered where another sign-in
+		// method exists)
 		const victimId = await createVictim(page, 'ui-strip@test.com', 'UI Strip');
+		linkUserToOAuth(victimId);
 
-		// The strip needs 188px of room, so it holds one line to 336px and wraps
-		// below. 360px covers the fitting case; 320px covers the case that used to
-		// shrink; 300px is narrow enough that a strip which refused to wrap would be
-		// pushed clear of its row, which the containment check below then catches.
+		// The strip fits four of its five 44px squares on one line and wraps the
+		// fifth below it at every phone width, so all three widths exercise the
+		// wrap case; 300px is narrow enough that a strip which refused to wrap
+		// would be pushed clear of its row, which the containment check below
+		// then catches.
 		for (const [width, fitsOneLine] of [
-			[360, true],
+			[360, false],
 			[320, false],
 			[300, false]
 		] as const) {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,17 +1,14 @@
-import { existsSync, unlinkSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { randomUUID } from 'crypto';
 
-const TEST_DB = './data/test-crumbs.db';
 export const TEST_CREDENTIALS_FILE = './data/test-credentials.json';
 
 export default function globalSetup() {
-	// Clean test database before E2E run so each run starts fresh
-	for (const ext of ['', '-journal', '-wal', '-shm']) {
-		const path = `${TEST_DB}${ext}`;
-		if (existsSync(path)) {
-			unlinkSync(path);
-		}
-	}
+	// The test database is wiped before the webServer starts (see the
+	// webServer.command in playwright.config.ts), NOT here: Playwright brings
+	// the webServer up before globalSetup runs, so deleting the SQLite files
+	// here would orphan the server's open database onto a deleted inode and
+	// tests that read the database file directly would see an empty schema.
 
 	// Generate random passwords for this test run, shared across all workers
 	writeFileSync(


### PR DESCRIPTION
## What
Admins can now reset the password of an OAuth-only user, which creates
credentials for that account and enables password login. A new
"Disable password login" row action (shown only on OAuth-linked rows)
removes those credentials again. Resetting a password also revokes all
existing sessions.

Supersedes #81, which GitHub auto-closed when the repository history was
rewritten to replace the author's work email (no content changed).

## Changes
- `users.password_login_enabled` column (Drizzle migration 0005)
- Admin reset: sets the password, enables login, revokes sessions
- New "Disable password login" action: clears the password and disables
  login (only available on OAuth-linked accounts)
- Account endpoint refuses password updates on OAuth-linked users
- Docs: ARCHITECTURE, AUTH, FEATURES updated

## Testing
- Unit: 345/345 pass
- svelte-check: 0 errors (14 pre-existing warnings)
- e2e: 137/137 pass — including a fix to the e2e setup: Playwright
  starts the webServer *before* globalSetup, so wiping the SQLite DB in
  globalSetup orphaned the server's open database onto a deleted inode
  and tests reading the DB file directly failed with
  "no such table: users". The wipe now runs as part of the webServer
  command, before the server opens the DB.

## Notes
`pnpm lint` fails repo-wide (no ESLint config file is tracked) — this is
pre-existing and unrelated to this PR.