### PR TITLE
fix(theme): map all prose colour variables to theme tokens for dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -88,14 +88,29 @@ body::before {
 	to { transform: translateY(0); }
 }
 
-/* Prose overrides for parchment theme */
+/* Prose overrides for parchment theme.
+   The typography plugin gives every element type its own --tw-prose-* variable,
+   each defaulting to a fixed grey. Anything not remapped here stays that grey in
+   dark mode (bold text was near-black on ink — see issue #86), so map them all. */
 .prose {
 	--tw-prose-body: var(--text);
 	--tw-prose-headings: var(--text);
+	--tw-prose-lead: var(--text-muted);
 	--tw-prose-links: var(--primary);
+	--tw-prose-bold: var(--text);
+	--tw-prose-counters: var(--text-muted);
+	--tw-prose-bullets: var(--text-muted);
+	--tw-prose-hr: var(--border-subtle);
+	--tw-prose-quotes: var(--text);
+	--tw-prose-quote-borders: var(--border-subtle);
+	--tw-prose-captions: var(--text-muted);
+	--tw-prose-kbd: var(--text);
+	--tw-prose-kbd-shadows: color-mix(in oklab, var(--text) 10%, transparent);
 	--tw-prose-code: var(--text);
-	--tw-prose-pre-bg: var(--bg-surface);
 	--tw-prose-pre-code: var(--text);
+	--tw-prose-pre-bg: var(--bg-surface);
+	--tw-prose-th-borders: var(--border-subtle);
+	--tw-prose-td-borders: var(--border-subtle);
 }
 
 .prose :where(code):not(:where([class~="not-prose"] *)) {

--- a/tests/e2e/dark-mode.spec.ts
+++ b/tests/e2e/dark-mode.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, createNote } from './helpers/fixtures.js';
+import { test, expect, createNote, noteCard } from './helpers/fixtures.js';
 
 test.describe.serial('Dark mode', () => {
 	test('Scenario: Theme toggle persists selection across page reload', async ({
@@ -107,6 +107,40 @@ test.describe.serial('Dark mode', () => {
 			'background-color',
 			'rgb(208, 79, 67)'
 		);
+
+		await page.getByTestId('close-editor-btn').click();
+	});
+
+	test('Scenario: Bold text in notes uses the theme text colour in dark mode', async ({
+		authenticatedPage: page
+	}) => {
+		// Given a note with bold content exists
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+		await createNote(page, 'Bold Contrast Note', 'Plain then **bold words** here');
+
+		// And dark theme is active
+		await page.goto('/settings/preferences');
+		await page.waitForLoadState('networkidle');
+		await page.getByTestId('pref-theme-dark').click();
+		await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+
+		// When viewing the note on the notes page
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+		const preview = noteCard(page, 'Bold Contrast Note').getByTestId('note-content-preview');
+		const boldInCard = preview.locator('strong');
+		await expect(boldInCard).toHaveText('bold words');
+
+		// Then the bold text is rendered in the dark theme's text colour (--text = #ece3d3),
+		// not the typography plugin's hardcoded near-black
+		await expect(boldInCard).toHaveCSS('color', 'rgb(236, 227, 211)');
+
+		// And the same holds inside the editor
+		await noteCard(page, 'Bold Contrast Note').click();
+		const boldInEditor = page.getByTestId('tiptap-editor').locator('.tiptap strong');
+		await expect(boldInEditor).toHaveText('bold words');
+		await expect(boldInEditor).toHaveCSS('color', 'rgb(236, 227, 211)');
 
 		await page.getByTestId('close-editor-btn').click();
 	});


### PR DESCRIPTION
Fixes #86

## Problem

Bold text inside notes rendered near-black in dark mode. The reporter saw it on iOS Safari, but it reproduces in every browser: the cause is CSS, not platform-specific.

The `@tailwindcss/typography` plugin gives each prose element its own `--tw-prose-*` variable, each defaulting to a fixed grey. The parchment override in `src/app.css` only remapped body, headings, links and code. Everything else kept its light-mode grey when `data-theme="dark"` flipped the rest of the palette:

- `--tw-prose-bold`, `--tw-prose-quotes`, `--tw-prose-kbd`: near-black text on the dark surface
- `--tw-prose-counters`, `--tw-prose-bullets`: off-palette greys
- `--tw-prose-hr`, `--tw-prose-th-borders`, `--tw-prose-td-borders`: light greys reading as glare on ink

## Fix

Map every `--tw-prose-*` colour variable to a theme token (`--text`, `--text-muted`, `--border-subtle`). Since the tokens already switch under `[data-theme="dark"]`, no separate dark rule is needed. The `kbd` shadow uses `color-mix` on `--text` so it tracks the theme too.

## Test

New e2e scenario in `tests/e2e/dark-mode.spec.ts`: a note with `**bold words**` is created, dark theme is enabled, and the `<strong>` in both the card preview and the editor must compute to `--text` (`rgb(236, 227, 211)`). Watched it fail first with the plugin's `gray-900` (`oklch(0.21 0.034 264.665)`), then pass.

- `pnpm check`: 0 errors
- `dark-mode`, `formatting`, `public-sharing` e2e specs: 27 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
