### PR TITLE
fix: render empty task list items as checkboxes in note previews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,8 @@ A `Makefile` wraps all common tasks for tool-agnostic usage. Run `make help` to 
 - **Conventional commits**: Use `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:` prefixes
 - **Commit regularly**: Bundle related changes into logical commits after each step or feature slice — don't accumulate a large diff
 - **Main branch**: `main` — use as base for all PRs and feature branches
-- **Feature branches**: Use `feat/<name>` branches with worktrees for isolation
+- **Always work in a worktree**: Never edit files in the main checkout. Before touching any file, create a dedicated worktree (`EnterWorktree` or `git worktree add .worktrees/<name> -b <branch>`) on a fresh branch from `origin/main`, do all work, commits, and PR creation from there. This keeps the main checkout clean and lets several tasks run side by side without clobbering each other's uncommitted changes.
+- **Feature branches**: Use `feat/<name>` (or `fix/<name>`) branches, one per worktree
 - **Rebase before PR**: Always `git rebase origin/main` (not merge) before pushing or creating a PR to keep a clean linear history and avoid merge conflicts in the PR
 
 ## CI/CD

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -95,6 +95,25 @@ describe('renderMarkdown', () => {
 		expect(html).toContain('disabled');
 		expect(html).toContain('class="task-checkbox"');
 	});
+
+	it('should render an empty task item as a checkbox, not literal brackets', () => {
+		const html = renderMarkdown('- [ ] Train tickets\n- [ ]');
+		expect(html).not.toContain('[ ]');
+		expect(html.match(/type="checkbox"/g)).toHaveLength(2);
+	});
+
+	it('should render an empty checked task item as a checked checkbox', () => {
+		const html = renderMarkdown('- [x]');
+		expect(html).not.toContain('[x]');
+		expect(html).toContain('<input type="checkbox" checked disabled class="task-checkbox">');
+		expect(html).toContain('class="task-list"');
+	});
+
+	it('should not treat brackets glued to text as a task marker', () => {
+		const html = renderMarkdown('- [ ]x');
+		expect(html).not.toContain('type="checkbox"');
+		expect(html).toContain('[ ]x');
+	});
 });
 
 describe('stripMarkdown', () => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -33,12 +33,16 @@ md.core.ruler.after('inline', 'task-lists', (state) => {
 	for (let i = 0; i < tokens.length; i++) {
 		if (tokens[i].type !== 'inline') continue;
 		const content = tokens[i].content;
-		if (content.startsWith('[ ] ') || content.startsWith('[x] ')) {
-			const checked = content.startsWith('[x] ');
+		// markdown-it trims trailing whitespace from inline content, so an item
+		// with no text after the marker arrives as exactly "[ ]" — match the
+		// marker followed by a space or end-of-content.
+		const marker = /^\[( |x)\](?: |$)/.exec(content);
+		if (marker) {
+			const checked = marker[1] === 'x';
 			const checkbox = checked
 				? '<input type="checkbox" checked disabled class="task-checkbox" /> '
 				: '<input type="checkbox" disabled class="task-checkbox" /> ';
-			tokens[i].content = content.slice(4);
+			tokens[i].content = content.slice(marker[0].length);
 			tokens[i].children = md.parseInline(tokens[i].content, state.env)[0].children;
 			// Prepend checkbox
 			const token = new state.Token('html_inline', '', 0);


### PR DESCRIPTION
## Summary

- An empty task item in a rich-text note (`- [ ]` with no text) rendered as literal `[ ]` in the note card preview while the editor showed a checkbox. The task-list rule in `src/lib/utils/markdown.ts` only matched a marker followed by a space, and markdown-it trims trailing whitespace from inline content, so an empty item never matched.
- The rule now matches the marker followed by a space or end-of-content and strips only what it matched. `[ ]x` glued to text still renders literally.
- Adds a "always work in a worktree" rule to the Git conventions in `CLAUDE.md`.

## Test plan

- [x] New unit tests: empty unchecked item, empty checked item, brackets glued to text (fail before, pass after)
- [x] `pnpm test:unit` — 355 passed
- [x] `pnpm check` — 0 errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
